### PR TITLE
[Style/#85] Overlay 및 전체 레이아웃 관련 수정

### DIFF
--- a/src/pages/filter/Filter.tsx
+++ b/src/pages/filter/Filter.tsx
@@ -19,6 +19,7 @@ import {
   SERVING_SIZE,
 } from '@pages/filter/constant/filter-option-constants';
 import Button from '@shared/components/button/Button';
+import Overlay from '@shared/components/overlay/Overlay';
 
 interface FilterState {
   eventType: string | null;
@@ -132,11 +133,11 @@ export default function Filter() {
           options={EVENT_TYPE}
           handleSelectFilter={value => handleSelectSingle('eventType', value)}
         />
-        <div className='bg-grayscale-100 h-[0.1rem] w-full' />
+        <div className='h-[0.1rem] w-full bg-grayscale-100' />
 
         <div className='mb-[2rem] flex flex-col gap-[2rem]'>
           <div className='flex flex-row items-center justify-between'>
-            <h2 className='title-b-14 px-[0.5rem]'>일정</h2>
+            <h2 className='px-[0.5rem] title-b-14'>일정</h2>
             <ButtonText handleClick={handleAddSchedule}>
               일정 추가하기
             </ButtonText>
@@ -150,7 +151,7 @@ export default function Filter() {
             />
           ))}
         </div>
-        <div className='bg-grayscale-100 h-[0.1rem] w-full' />
+        <div className='h-[0.1rem] w-full bg-grayscale-100' />
 
         <FilterChipGroup
           filterTitle='수량'
@@ -158,7 +159,7 @@ export default function Filter() {
           options={SERVING_SIZE}
           handleSelectFilter={value => handleSelectSingle('servingSize', value)}
         />
-        <div className='bg-grayscale-100 h-[0.1rem] w-full' />
+        <div className='h-[0.1rem] w-full bg-grayscale-100' />
 
         <FilterChipGroup
           filterTitle='음식 종류'
@@ -167,7 +168,7 @@ export default function Filter() {
           multiSelectable
           handleSelectFilter={value => handleSelectMulti('foodType', value)}
         />
-        <div className='bg-grayscale-100 h-[0.1rem] w-full' />
+        <div className='h-[0.1rem] w-full bg-grayscale-100' />
 
         <FilterChipGroup
           filterTitle='전기 사용'
@@ -177,7 +178,7 @@ export default function Filter() {
             handleSelectSingle('electricityUsage', value)
           }
         />
-        <div className='bg-grayscale-100 h-[0.1rem] w-full' />
+        <div className='h-[0.1rem] w-full bg-grayscale-100' />
 
         <FilterChipGroup
           filterTitle='결제 방법'
@@ -187,26 +188,34 @@ export default function Filter() {
         />
       </div>
 
-      <BottomSheet
+      <Overlay
         isOpen={isBottomSheetOpen}
-        handleCloseBottomSheet={handleCloseCalendar}
-        sheetContent={
-          currentDateIndex !== null ? (
-            <Calendar
-              selectedDate={
-                filters.date?.[currentDateIndex] ?? {
-                  startDate: null,
-                  endDate: null,
+        position='bottom'
+        handleClose={handleCloseCalendar}
+      >
+        <BottomSheet
+          isOpen={isBottomSheetOpen}
+          handleCloseBottomSheet={handleCloseCalendar}
+          sheetContent={
+            currentDateIndex !== null ? (
+              <Calendar
+                selectedDate={
+                  filters.date?.[currentDateIndex] ?? {
+                    startDate: null,
+                    endDate: null,
+                  }
                 }
-              }
-              handleApplyDate={date => handleApplyDate(date, currentDateIndex)}
-              handleCloseBottomSheet={handleCloseCalendar}
-              isOpen={isBottomSheetOpen}
-            />
-          ) : null
-        }
-        sheetHeight={490}
-      />
+                handleApplyDate={date =>
+                  handleApplyDate(date, currentDateIndex)
+                }
+                handleCloseBottomSheet={handleCloseCalendar}
+                isOpen={isBottomSheetOpen}
+              />
+            ) : null
+          }
+          sheetHeight={490}
+        />
+      </Overlay>
 
       <div
         className={cn(

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -31,7 +31,7 @@ const Home = () => {
   };
 
   return (
-    <div className='relative'>
+    <div>
       {/* Modal */}
       <Overlay
         isOpen={isModalOpen}

--- a/src/shared/components/overlay/Overlay.tsx
+++ b/src/shared/components/overlay/Overlay.tsx
@@ -56,7 +56,7 @@ export default function Overlay({
     <div
       onClick={handleOverlayClick}
       className={cn(
-        'z-100 fixed inset-0 flex h-dvh w-full max-w-[60rem] bg-black/50',
+        'fixed left-1/2 top-[0] z-50 flex h-dvh w-full max-w-[60rem] -translate-x-1/2 bg-black/50',
         getPositionClasses(),
         'transition-opacity duration-300 ease-in-out',
         isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',

--- a/src/shared/styles/sharedStyles.css
+++ b/src/shared/styles/sharedStyles.css
@@ -64,10 +64,10 @@
     box-sizing: border-box;
   }
   #root {
-    background: #f8fafb;
+    background-color: var(--color-grayscale-50);
   }
   main {
-    background: #fff;
+    background-color: var(--color-white);
     box-shadow: 0 0 10px 4px rgba(0, 0, 0, 0.04);
   }
 }

--- a/src/shared/styles/sharedStyles.css
+++ b/src/shared/styles/sharedStyles.css
@@ -63,6 +63,13 @@
   * {
     box-sizing: border-box;
   }
+  #root {
+    background: #f8fafb;
+  }
+  main {
+    background: #fff;
+    box-shadow: 0 0 10px 4px rgba(0, 0, 0, 0.04);
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## 📌 Related Issues

- close #85 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- Overlay 컴포넌트 웹 환경에서도 적절히 동작하도록 스타일 수정
- sharedStyle에 #root 배경색 추가 / main 태그 배경색 white 및 shadow 추가 
- Filter 페이지 캘린더 바텀시트에 Overlay 적용

## ⭐ PR Point (To Reviewer)

- 변경된 사항은 sharedStyle.css와 Overlay 컴포넌트만 확인해주시면 될 것 같습니다!
- top, bottom 등의 속성에는 top-0 이런식이 아닌 top-[0] 또는 top-[0rem]으로 해야 적용이 됩니다. inset도 마찬가지이니 추후 개발 시에도 참고 부탁드립니다!
- 
## 📷 Screenshot

<img width="1179" height="1214" alt="image" src="https://github.com/user-attachments/assets/3d46b449-fb6c-4ee8-aad8-b847ac5991ca" />
<img width="1093" height="1173" alt="image" src="https://github.com/user-attachments/assets/1559deee-6076-4f5a-bade-2dce8d7bb438" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* Refactor
  - 필터 화면의 하단 드로어를 Overlay로 감싸고 닫기 동작을 Overlay가 처리하도록 변경(캘린더 동작 불변).
  - 홈 화면 루트 컨테이너에서 relative 클래스 제거(동작 변화 없음, 레이아웃 영향 가능).
  - Overlay의 위치·정렬 및 z-index 조정: 가로 중앙 정렬 및 z-index 하향.

* Style
  - #root에 배경색 추가(#f8fafb), main에 흰 배경 및 은은한 그림자 적용.
  - 일부 클래스 순서 및 헤더 패딩/타이포 조정(시각적 변경만).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->