### PR TITLE
[Init/#76] swagger typescript api 세팅

### DIFF
--- a/apis/Auth.ts
+++ b/apis/Auth.ts
@@ -1,0 +1,43 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { AuthTokenRequest, GetTokenData } from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Auth<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description loginTokenKey를 통해 JWT Access Token을 발급받습니다. 카카오 소셜 로그인 직후 리다이렉트 url의 쿼리 파라미터에서 loginTokenKey를 꺼내서 요청해주세요.
+   *
+   * @tags Auth API
+   * @name GetToken
+   * @summary JWT Access Token 발급
+   * @request POST:/auth/token
+   * @secure
+   * @response `200` `GetTokenData` OK
+   * @response `400` `void`
+   * @response `401` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getToken = (data: AuthTokenRequest, params: RequestParams = {}) =>
+    this.request<GetTokenData, void>({
+      path: `/auth/token`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+}

--- a/apis/Members.ts
+++ b/apis/Members.ts
@@ -1,0 +1,208 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  GetMemberReservationDetailData,
+  GetMemberReservationsData,
+  GetReservationsForRatingData,
+  GetSavedFoodTrucksData,
+  RegisterRatingRequest,
+  RegisterRatingsData,
+  UpdateFoodTruckSaveStatusData,
+  UpdateFoodTruckSaveStatusRequest,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Members<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description 지난 예약에 대한 푸드트럭 평점을 남깁니다.
+   *
+   * @tags Member API
+   * @name RegisterRatings
+   * @summary 평점 등록
+   * @request POST:/members/me/ratings
+   * @secure
+   * @response `200` `RegisterRatingsData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  registerRatings = (data: RegisterRatingRequest, params: RequestParams = {}) =>
+    this.request<RegisterRatingsData, void>({
+      path: `/members/me/ratings`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 푸드트럭 저장상태를 변경합니다. (저장/저장취소)
+   *
+   * @tags Member API
+   * @name UpdateFoodTruckSaveStatus
+   * @summary 푸드트럭 저장상태 변경
+   * @request PATCH:/members/me/food-trucks/{foodTruckId}
+   * @secure
+   * @response `200` `UpdateFoodTruckSaveStatusData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `409` `void`
+   * @response `500` `void`
+   */
+  updateFoodTruckSaveStatus = (
+    foodTruckId: number,
+    data: UpdateFoodTruckSaveStatusRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<UpdateFoodTruckSaveStatusData, void>({
+      path: `/members/me/food-trucks/${foodTruckId}`,
+      method: "PATCH",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 일반 유저의 예약 내역 목록을 조회합니다.
+   *
+   * @tags Member API
+   * @name GetMemberReservations
+   * @summary 일반 유저 예약 내역 목록 조회 (무한 스크롤)
+   * @request GET:/members/me/reservations
+   * @secure
+   * @response `200` `GetMemberReservationsData` OK
+   */
+  getMemberReservations = (
+    query: {
+      /**
+       * 조회할 예약 상태
+       * @example "PENDING"
+       */
+      status:
+        | "PENDING"
+        | "CONFIRMED"
+        | "CONFIRMED_REQUESTED"
+        | "CANCELLED"
+        | "CANCELED_REQUESTED";
+      /**
+       * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
+       * @format int64
+       * @example 120
+       */
+      "cursorPagingRequest.cursor"?: number;
+      /**
+       * 한 페이지에 조회할 개수
+       * @format int32
+       * @min 1
+       * @default 20
+       */
+      "cursorPagingRequest.size"?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<GetMemberReservationsData, any>({
+      path: `/members/me/reservations`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 예약 ID로 예약 상세 정보를 조회합니다.
+   *
+   * @tags Member API
+   * @name GetMemberReservationDetail
+   * @summary 일반 유저 예약 상세 조회
+   * @request GET:/members/me/reservations/{reservationId}
+   * @secure
+   * @response `200` `GetMemberReservationDetailData` OK
+   */
+  getMemberReservationDetail = (
+    reservationId: number,
+    params: RequestParams = {},
+  ) =>
+    this.request<GetMemberReservationDetailData, any>({
+      path: `/members/me/reservations/${reservationId}`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 평점을 등록할 수 있는 지난 예약 목록을 조회합니다.
+   *
+   * @tags Member API
+   * @name GetReservationsForRating
+   * @summary 평점을 등록할 예약 조회
+   * @request GET:/members/me/ratings/reservations
+   * @secure
+   * @response `200` `GetReservationsForRatingData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getReservationsForRating = (params: RequestParams = {}) =>
+    this.request<GetReservationsForRatingData, void>({
+      path: `/members/me/ratings/reservations`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 저장한 푸드트럭 목록을 조회합니다.
+   *
+   * @tags Member API
+   * @name GetSavedFoodTrucks
+   * @summary 저장한 푸드트럭 목록 조회
+   * @request GET:/members/me/food-trucks
+   * @secure
+   * @response `200` `GetSavedFoodTrucksData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getSavedFoodTrucks = (
+    query?: {
+      /**
+       * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
+       * @format int64
+       * @example 120
+       */
+      cursor?: number;
+      /**
+       * 한 페이지에 조회할 개수
+       * @format int32
+       * @min 1
+       * @default 20
+       */
+      size?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<GetSavedFoodTrucksData, void>({
+      path: `/members/me/food-trucks`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+}

--- a/apis/Owners.ts
+++ b/apis/Owners.ts
@@ -1,0 +1,371 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  DeleteBankAccountData,
+  DeleteChatTemplateData,
+  DeleteFoodTruckData,
+  GetBankAccountData,
+  GetChatTemplatesData,
+  GetMyFoodTrucksData,
+  GetOwnerReservationsData,
+  GetReservationDetailData,
+  RegisterBankAccountData,
+  RegisterBankAccountRequest,
+  RegisterChatTemplateData,
+  RegisterChatTemplateRequest,
+  UpdateBankAccountData,
+  UpdateBankAccountRequest,
+  UpdateChatTemplateData,
+  UpdateChatTemplateRequest,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Owners<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description 사장님이 자주 쓰는 채팅을 수정합니다.
+   *
+   * @tags Owner API
+   * @name UpdateChatTemplate
+   * @summary 자주 쓰는 채팅 수정
+   * @request PUT:/owners/me/chat-templates/{chatTemplateId}
+   * @secure
+   * @response `200` `UpdateChatTemplateData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  updateChatTemplate = (
+    chatTemplateId: number,
+    data: UpdateChatTemplateRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<UpdateChatTemplateData, void>({
+      path: `/owners/me/chat-templates/${chatTemplateId}`,
+      method: "PUT",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자주 쓰는 채팅을 삭제합니다.
+   *
+   * @tags Owner API
+   * @name DeleteChatTemplate
+   * @summary 자주 쓰는 채팅 삭제
+   * @request DELETE:/owners/me/chat-templates/{chatTemplateId}
+   * @secure
+   * @response `200` `DeleteChatTemplateData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  deleteChatTemplate = (chatTemplateId: number, params: RequestParams = {}) =>
+    this.request<DeleteChatTemplateData, void>({
+      path: `/owners/me/chat-templates/${chatTemplateId}`,
+      method: "DELETE",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자신의 은행 계좌를 수정합니다.
+   *
+   * @tags Owner API
+   * @name UpdateBankAccount
+   * @summary 은행 계좌 수정
+   * @request PUT:/owners/me/bank-accounts/{bankAccountId}
+   * @secure
+   * @response `200` `UpdateBankAccountData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `409` `void`
+   * @response `500` `void`
+   */
+  updateBankAccount = (
+    bankAccountId: number,
+    data: UpdateBankAccountRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<UpdateBankAccountData, void>({
+      path: `/owners/me/bank-accounts/${bankAccountId}`,
+      method: "PUT",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자신의 은행 계좌를 삭제합니다.
+   *
+   * @tags Owner API
+   * @name DeleteBankAccount
+   * @summary 은행 계좌 삭제
+   * @request DELETE:/owners/me/bank-accounts/{bankAccountId}
+   * @secure
+   * @response `200` `DeleteBankAccountData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `409` `void`
+   * @response `500` `void`
+   */
+  deleteBankAccount = (bankAccountId: number, params: RequestParams = {}) =>
+    this.request<DeleteBankAccountData, void>({
+      path: `/owners/me/bank-accounts/${bankAccountId}`,
+      method: "DELETE",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자주 쓰는 채팅을 조회합니다.
+   *
+   * @tags Owner API
+   * @name GetChatTemplates
+   * @summary 자주 쓰는 채팅 조회
+   * @request GET:/owners/me/chat-templates
+   * @secure
+   * @response `200` `GetChatTemplatesData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getChatTemplates = (params: RequestParams = {}) =>
+    this.request<GetChatTemplatesData, void>({
+      path: `/owners/me/chat-templates`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자주 쓰는 채팅을 등록합니다.
+   *
+   * @tags Owner API
+   * @name RegisterChatTemplate
+   * @summary 자주 쓰는 채팅 등록
+   * @request POST:/owners/me/chat-templates
+   * @secure
+   * @response `200` `RegisterChatTemplateData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  registerChatTemplate = (
+    data: RegisterChatTemplateRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<RegisterChatTemplateData, void>({
+      path: `/owners/me/chat-templates`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자신의 은행 계좌를 조회합니다.
+   *
+   * @tags Owner API
+   * @name GetBankAccount
+   * @summary 은행 계좌 조회
+   * @request GET:/owners/me/bank-accounts
+   * @secure
+   * @response `200` `GetBankAccountData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getBankAccount = (params: RequestParams = {}) =>
+    this.request<GetBankAccountData, void>({
+      path: `/owners/me/bank-accounts`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님이 자신의 은행 계좌를 등록합니다.
+   *
+   * @tags Owner API
+   * @name RegisterBankAccount
+   * @summary 은행 계좌 등록
+   * @request POST:/owners/me/bank-accounts
+   * @secure
+   * @response `200` `RegisterBankAccountData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `409` `void`
+   * @response `500` `void`
+   */
+  registerBankAccount = (
+    data: RegisterBankAccountRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<RegisterBankAccountData, void>({
+      path: `/owners/me/bank-accounts`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 사장님의 예약 내역 목록을 조회합니다.
+   *
+   * @tags Owner API
+   * @name GetOwnerReservations
+   * @summary 사장님 예약 내역 목록 조회 (무한 스크롤)
+   * @request GET:/owners/me/reservations
+   * @secure
+   * @response `200` `GetOwnerReservationsData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getOwnerReservations = (
+    query: {
+      /**
+       * 조회할 예약 상태
+       * @example "PENDING"
+       */
+      status:
+        | "PENDING"
+        | "CONFIRMED"
+        | "CONFIRMED_REQUESTED"
+        | "CANCELLED"
+        | "CANCELED_REQUESTED";
+      /**
+       * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
+       * @format int64
+       * @example 120
+       */
+      "cursorPagingRequest.cursor"?: number;
+      /**
+       * 한 페이지에 조회할 개수
+       * @format int32
+       * @min 1
+       * @default 20
+       */
+      "cursorPagingRequest.size"?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<GetOwnerReservationsData, void>({
+      path: `/owners/me/reservations`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 예약 ID로 예약 상세 정보를 조회합니다.
+   *
+   * @tags Owner API
+   * @name GetReservationDetail
+   * @summary 사장님 예약 상세 조회
+   * @request GET:/owners/me/reservations/{reservationId}
+   * @secure
+   * @response `200` `GetReservationDetailData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getReservationDetail = (reservationId: number, params: RequestParams = {}) =>
+    this.request<GetReservationDetailData, void>({
+      path: `/owners/me/reservations/${reservationId}`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님 - 나의 푸드트럭 목록을 조회합니다.
+   *
+   * @tags Owner API
+   * @name GetMyFoodTrucks
+   * @summary 나의 푸드트럭 목록 조회 (무한 스크롤)
+   * @request GET:/owners/me/food-trucks
+   * @secure
+   * @response `200` `GetMyFoodTrucksData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getMyFoodTrucks = (
+    query?: {
+      /**
+       * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
+       * @format int64
+       * @example 120
+       */
+      cursor?: number;
+      /**
+       * 한 페이지에 조회할 개수
+       * @format int32
+       * @min 1
+       * @default 20
+       */
+      size?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<GetMyFoodTrucksData, void>({
+      path: `/owners/me/food-trucks`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님 - 푸드트럭을 삭제합니다.
+   *
+   * @tags Owner API
+   * @name DeleteFoodTruck
+   * @summary 나의 푸드트럭 삭제
+   * @request DELETE:/owners/me/food-trucks/{foodTruckId}
+   * @secure
+   * @response `200` `DeleteFoodTruckData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  deleteFoodTruck = (foodTruckId: number, params: RequestParams = {}) =>
+    this.request<DeleteFoodTruckData, void>({
+      path: `/owners/me/food-trucks/${foodTruckId}`,
+      method: "DELETE",
+      secure: true,
+      ...params,
+    });
+}

--- a/apis/Regions.ts
+++ b/apis/Regions.ts
@@ -1,0 +1,91 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import { GetRegionsData, SearchRegionsData } from "./data-contracts";
+import { HttpClient, RequestParams } from "./http-client";
+
+export class Regions<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description depth, parentCode 를 기반으로 지역을 조회합니다.
+   *
+   * @tags Region API
+   * @name GetRegions
+   * @summary 지역 조회
+   * @request GET:/regions
+   * @secure
+   * @response `200` `GetRegionsData` OK
+   * @response `400` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getRegions = (
+    query: {
+      /**
+       * 행정 구역 깊이 (1: 시/도, 2: 시/군/구, 3: 동/읍/면)
+       * @format int32
+       * @min 1
+       * @max 3
+       * @example 1
+       */
+      depth: number;
+      /**
+       * 부모 행정동 코드 (depth=2/3일 때 필수)
+       * @format int64
+       * @example 11
+       */
+      parentCode?: number;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<GetRegionsData, void>({
+      path: `/regions`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 키워드를 부분문자열로 갖는 모든 지역을 검색합니다.
+   *
+   * @tags Region API
+   * @name SearchRegions
+   * @summary 지역 검색
+   * @request GET:/regions/search
+   * @secure
+   * @response `200` `SearchRegionsData` OK
+   * @response `400` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  searchRegions = (
+    query: {
+      /**
+       * 지역명 검색 키워드(부분일치, fullName 기준)
+       * @minLength 1
+       * @example "광"
+       */
+      keyword: string;
+    },
+    params: RequestParams = {},
+  ) =>
+    this.request<SearchRegionsData, void>({
+      path: `/regions/search`,
+      method: "GET",
+      query: query,
+      secure: true,
+      ...params,
+    });
+}

--- a/apis/Reservations.ts
+++ b/apis/Reservations.ts
@@ -1,0 +1,102 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  CreateReservationData,
+  CreateReservationRequest,
+  GetReservationData,
+  UpdateReservationData,
+  UpdateReservationRequest,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Reservations<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description 사장님이 작성한 예약 견적서를 조회합니다. 사장님, 일반 유저 모두 조회 가능합니다.
+   *
+   * @tags Reservation API
+   * @name GetReservation
+   * @summary 예약 견적서 조회
+   * @request GET:/reservations/{reservationId}
+   * @secure
+   * @response `200` `GetReservationData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getReservation = (reservationId: number, params: RequestParams = {}) =>
+    this.request<GetReservationData, void>({
+      path: `/reservations/${reservationId}`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사장님이 작성한 예약 견적서를 수정합니다. 사장님, 일반 유저 모두 수정 가능합니다.
+   *
+   * @tags Reservation API
+   * @name UpdateReservation
+   * @summary 예약 견적서 수정
+   * @request PUT:/reservations/{reservationId}
+   * @secure
+   * @response `200` `UpdateReservationData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  updateReservation = (
+    reservationId: number,
+    data: UpdateReservationRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<UpdateReservationData, void>({
+      path: `/reservations/${reservationId}`,
+      method: "PUT",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+  /**
+   * @description 사장님이 예약 견적서를 작성합니다. 예약 견적서 정보에 따라 예약이 생성됩니다. (예약 상태: 예약 대기)
+   *
+   * @tags Reservation API
+   * @name CreateReservation
+   * @summary 예약 견적서 작성 (예약 생성)
+   * @request POST:/reservations
+   * @secure
+   * @response `200` `CreateReservationData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  createReservation = (
+    data: CreateReservationRequest,
+    params: RequestParams = {},
+  ) =>
+    this.request<CreateReservationData, void>({
+      path: `/reservations`,
+      method: "POST",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+}

--- a/apis/Users.ts
+++ b/apis/Users.ts
@@ -1,0 +1,67 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import {
+  GetUserInfoData,
+  UpdateUserInfoData,
+  UpdateUserInfoRequest,
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
+
+export class Users<
+  SecurityDataType = unknown,
+> extends HttpClient<SecurityDataType> {
+  /**
+   * @description 사용자(고객)의 정보를 조회합니다. (사장님, 일반유저 무관)
+   *
+   * @tags User API
+   * @name GetUserInfo
+   * @summary [마이페이지] 회원 정보 조회
+   * @request GET:/users/me
+   * @secure
+   * @response `200` `GetUserInfoData` OK
+   * @response `400` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getUserInfo = (params: RequestParams = {}) =>
+    this.request<GetUserInfoData, void>({
+      path: `/users/me`,
+      method: "GET",
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 사용자(고객)의 정보를 수정합니다. (사장님, 일반유저 무관)
+   *
+   * @tags User API
+   * @name UpdateUserInfo
+   * @summary [마이페이지] 회원 정보 수정
+   * @request PUT:/users/me
+   * @secure
+   * @response `200` `UpdateUserInfoData` OK
+   * @response `400` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  updateUserInfo = (data: UpdateUserInfoRequest, params: RequestParams = {}) =>
+    this.request<UpdateUserInfoData, void>({
+      path: `/users/me`,
+      method: "PUT",
+      body: data,
+      secure: true,
+      type: ContentType.Json,
+      ...params,
+    });
+}

--- a/apis/data-contracts.ts
+++ b/apis/data-contracts.ts
@@ -1,0 +1,884 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+/** 사용자 정보 수정 요청 DTO */
+export interface UpdateUserInfoRequest {
+  /**
+   * 프로필 이미지 URL
+   * @minLength 1
+   * @example "https://example.com/profile.jpg"
+   */
+  profileImageUrl: string;
+  /**
+   * 사용자 이름
+   * @minLength 1
+   * @example "홍길동"
+   */
+  name: string;
+  /**
+   * 사용자 이메일
+   * @minLength 1
+   * @example "chacall@kokuk.ac.kr"
+   */
+  email: string;
+  /**
+   * 사용자 성별
+   * @minLength 1
+   * @example "남성"
+   */
+  gender: string;
+  /**
+   * 약관 동의 여부
+   * @example true
+   */
+  termAgreed: boolean;
+}
+
+export interface BaseResponseVoid {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: any;
+}
+
+export interface UpdateReservationRequest {
+  /**
+   * 예약 주소 (시/구/동)
+   * @minLength 1
+   * @example "서울시 강남구 역삼동"
+   */
+  address: string;
+  /**
+   * 예약 상세 주소
+   * @minLength 1
+   * @example "역삼로 123"
+   */
+  detailAddress: string;
+  /**
+   * 예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)
+   * @maxItems 2
+   * @minItems 1
+   * @example ["2025.09.20 ~ 2025.09.20","2025.09.25 ~ 2025.09.25"]
+   */
+  reservationDates: string[];
+  /**
+   * 운영 시간 (형식: HH:MM ~ HH:MM)
+   * @minLength 1
+   * @pattern ^([01]\d|2[0-3]):([0-5]\d) ~ ([01]\d|2[0-3]):([0-5]\d)$
+   * @example "15:00 ~ 16:00"
+   */
+  operationHour: string;
+  /**
+   * 메뉴
+   * @minLength 1
+   * @example "떡볶이, 순대, 튀김"
+   */
+  menu: string;
+  /**
+   * 예약금 (0 이상)
+   * @format int32
+   * @example 50000
+   */
+  deposit: number;
+  /**
+   * 전기 사용 여부
+   * @example true
+   */
+  isUseElectricity: boolean;
+  /**
+   * 기타 요청 사항
+   * @example "주차 공간이 넓었으면 좋겠습니다."
+   */
+  etcRequest?: string;
+}
+
+export interface BaseResponseReservationIdResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: ReservationIdResponse;
+}
+
+export interface ReservationIdResponse {
+  /**
+   * 생성된 예약 ID
+   * @format int64
+   * @example 1
+   */
+  reservationId?: number;
+}
+
+export interface UpdateChatTemplateRequest {
+  /**
+   * 자주 쓰는 채팅 내용
+   * @minLength 0
+   * @maxLength 500
+   * @example "저희집은 마라탕이 맛납니다"
+   */
+  content: string;
+}
+
+/** 은행 계좌 수정 요청 DTO */
+export interface UpdateBankAccountRequest {
+  /**
+   * 은행명
+   * @minLength 1
+   * @example "국민은행"
+   */
+  bankName: string;
+  /**
+   * 예금주명
+   * @minLength 1
+   * @example "홍길동"
+   */
+  accountHolderName: string;
+  /**
+   * 계좌번호
+   * @minLength 1
+   * @example "123-456-78901234"
+   */
+  accountNumber: string;
+}
+
+export interface CreateReservationRequest {
+  /**
+   * 푸드트럭 ID
+   * @format int64
+   * @example 1
+   */
+  foodTruckId: number;
+  /**
+   * 예약자(일반 유저) ID
+   * @format int64
+   * @example 2
+   */
+  reservationUserId: number;
+  /**
+   * 예약 주소 (시/구/동)
+   * @minLength 1
+   * @example "서울시 강남구 역삼동"
+   */
+  address: string;
+  /**
+   * 예약 상세 주소
+   * @minLength 1
+   * @example "역삼로 123"
+   */
+  detailAddress: string;
+  /**
+   * 예약 날짜 (최소 1개, 최대 2개) (형식: YYYY.MM.DD ~ YYYY.MM.DD)
+   * @maxItems 2
+   * @minItems 1
+   * @example ["2025.09.20 ~ 2025.09.20","2025.09.25 ~ 2025.09.25"]
+   */
+  reservationDates: string[];
+  /**
+   * 운영 시간 (형식: HH:MM ~ HH:MM)
+   * @minLength 1
+   * @pattern ^([01]\d|2[0-3]):([0-5]\d) ~ ([01]\d|2[0-3]):([0-5]\d)$
+   * @example "15:00 ~ 16:00"
+   */
+  operationHour: string;
+  /**
+   * 메뉴
+   * @minLength 1
+   * @example "떡볶이, 순대, 튀김"
+   */
+  menu: string;
+  /**
+   * 예약금 (0 이상)
+   * @format int32
+   * @example 50000
+   */
+  deposit: number;
+  /**
+   * 전기 사용 여부
+   * @example true
+   */
+  isUseElectricity: boolean;
+  /**
+   * 기타 요청 사항
+   * @example "주차 공간이 넓었으면 좋겠습니다."
+   */
+  etcRequest?: string;
+}
+
+export interface RegisterChatTemplateRequest {
+  /**
+   * 자주 쓰는 채팅 내용
+   * @minLength 0
+   * @maxLength 500
+   * @example "안녕하세요. 차콜 푸드트럭입니다!"
+   */
+  content: string;
+}
+
+/** 은행 계좌 등록 요청 DTO */
+export interface RegisterBankAccountRequest {
+  /**
+   * 은행명
+   * @minLength 1
+   * @example "국민은행"
+   */
+  bankName: string;
+  /**
+   * 예금주명
+   * @minLength 1
+   * @example "홍길동"
+   */
+  accountHolderName: string;
+  /**
+   * 계좌번호
+   * @minLength 1
+   * @example "123-456-78901234"
+   */
+  accountNumber: string;
+}
+
+/** 평점 등록 요청 DTO */
+export interface RegisterRatingRequest {
+  /**
+   * 예약 ID
+   * @format int64
+   * @example 1
+   */
+  reservationId: number;
+  /**
+   * 푸드트럭 ID
+   * @format int64
+   * @example 1
+   */
+  foodTruckId: number;
+  /**
+   * 평점 (0~5 범위 내에 0.5 단위)
+   * @pattern ^(?:[0-4](?:\.0|\.5)|5(?:\.0)?)$
+   * @example 4.5
+   */
+  rating: string;
+}
+
+export interface AuthTokenRequest {
+  /** @minLength 1 */
+  loginTokenKey: string;
+}
+
+export interface AuthTokenResponse {
+  token?: string;
+}
+
+export interface BaseResponseAuthTokenResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: AuthTokenResponse;
+}
+
+/** 푸드트럭 저장 상태 변경 요청 */
+export interface UpdateFoodTruckSaveStatusRequest {
+  /**
+   * 푸드트럭 저장 요청 여부, (true: 저장 / false: 저장 취소)
+   * @example true
+   */
+  isSavedRequest: boolean;
+}
+
+export interface BaseResponseSavedFoodTruckStatusResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: SavedFoodTruckStatusResponse;
+}
+
+export interface SavedFoodTruckStatusResponse {
+  isSaved?: boolean;
+}
+
+export interface BaseResponseUserResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: UserResponse;
+}
+
+export interface UserResponse {
+  /**
+   * 프로필 이미지 URL
+   * @example "http://image.png"
+   */
+  profileImageUrl?: string;
+  /**
+   * 이름
+   * @example "홍길동"
+   */
+  name?: string;
+  /**
+   * 이메일
+   * @example "email@email.com"
+   */
+  email?: string;
+  /**
+   * 성별
+   * @example "남성"
+   */
+  gender?: string;
+  /**
+   * 약관 동의 여부
+   * @example true
+   */
+  termAgreed?: boolean;
+}
+
+export interface BaseResponseReservationResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: ReservationResponse;
+}
+
+export interface ReservationResponse {
+  /**
+   * 예약 주소 (시/구/동)
+   * @example "서울시 강남구 역삼동"
+   */
+  address?: string;
+  /**
+   * 예약 상세 주소
+   * @example "역삼로 123"
+   */
+  detailAddress?: string;
+  /**
+   * 예약 날짜 (형식: YYYY.MM.DD ~ YYYY.MM.DD)
+   * @example ["2025.09.20 ~ 2025.09.20","2025.09.25 ~ 2025.09.25"]
+   */
+  reservationDates?: string[];
+  /**
+   * 운영 시간 (형식: HH:MM ~ HH:MM)
+   * @example "15:00 ~ 16:00"
+   */
+  operationHour?: string;
+  /**
+   * 메뉴
+   * @example "떡볶이, 순대, 튀김"
+   */
+  menu?: string;
+  /**
+   * 예약금 (0 이상)
+   * @format int32
+   * @example 50000
+   */
+  deposit?: number;
+  /**
+   * 전기 사용 여부
+   * @example true
+   */
+  isUseElectricity?: boolean;
+  /**
+   * 기타 요청 사항
+   * @example "주차 공간이 넓었으면 좋겠습니다."
+   */
+  etcRequest?: string;
+}
+
+export interface BaseResponseListRegionResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: RegionResponse[];
+}
+
+export interface RegionResponse {
+  /**
+   * 지역 이름
+   * @example "서울"
+   */
+  name?: string;
+  /**
+   * 지역 행정동 코드
+   * @format int64
+   * @example 11
+   */
+  code?: number;
+}
+
+export interface BaseResponseCursorPagingResponseOwnerReservationHistoryResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: CursorPagingResponseOwnerReservationHistoryResponse;
+}
+
+export interface CursorPagingResponseOwnerReservationHistoryResponse {
+  content?: OwnerReservationHistoryResponse[];
+  /** @format int64 */
+  lastCursor?: number;
+  hasNext?: boolean;
+}
+
+export interface OwnerReservationHistoryResponse {
+  /**
+   * 예약 내역 식별자
+   * @format int64
+   * @example 1
+   */
+  reservationId?: number;
+  /**
+   * 유저(고객) 프로필 이미지
+   * @example "http://image.png"
+   */
+  profileImage?: string;
+  /**
+   * 유저(고객) 이름
+   * @example "홍길동"
+   */
+  name?: string;
+  /**
+   * 예약 주소
+   * @example "서울 광진구 화양동"
+   */
+  address?: string;
+  /**
+   * 예약 날짜 및 운영 시간 정보 리스트 (최대 2개)
+   * @example ["2025-09-20 13시~19시","2025-09-21 13시~19시"]
+   */
+  dateTimeInfos?: string[];
+  /**
+   * 푸드트럭 이름
+   * @example "차콜 푸드트럭"
+   */
+  foodTruckName?: string;
+}
+
+export interface BaseResponseOwnerReservationDetailResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: OwnerReservationDetailResponse;
+}
+
+export interface OwnerReservationDetailResponse {
+  /**
+   * 상대방(손님)의 프로필 이미지 URL
+   * @example "https://image.url/path/profile.jpg"
+   */
+  profileImage?: string;
+  /**
+   * 상대방의 이름 또는 닉네임
+   * @example "김차콜"
+   */
+  name?: string;
+  /**
+   * 예약 주소
+   * @example "서울 광진구 화양동 123-45"
+   */
+  address?: string;
+  /**
+   * 예약 날짜 및 운영 시간 정보 리스트 (최대 2개)
+   * @example ["2025-09-20 13시~19시","2025-09-21 13시~19시"]
+   */
+  dateTimeInfos?: string[];
+  /**
+   * 견적서 PDF 다운로드 URL (null 일 수 있음)
+   * @example "https://storage.url/quotes/reservation_123.pdf"
+   */
+  pdfUrl?: string;
+  /**
+   * 운영 메뉴
+   * @example "핫도그, 국밥, 짜장면"
+   */
+  menu?: string;
+  /**
+   * 지불된 예약금액
+   * @example "50000원"
+   */
+  deposit?: string;
+  /**
+   * 전기 사용 가능 여부
+   * @example "가능"
+   */
+  electricityInfo?: string;
+  /**
+   * 기타 요청 사항 (null 일 수 있음)
+   * @example "음식을 많이 주세요, 늦지말아주세요"
+   */
+  etcRequest?: string;
+}
+
+export interface BaseResponseCursorPagingResponseMyFoodTruckResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: CursorPagingResponseMyFoodTruckResponse;
+}
+
+export interface CursorPagingResponseMyFoodTruckResponse {
+  content?: MyFoodTruckResponse[];
+  /** @format int64 */
+  lastCursor?: number;
+  hasNext?: boolean;
+}
+
+export interface MyFoodTruckResponse {
+  /**
+   * 푸드트럭 식별자
+   * @format int64
+   * @example 1
+   */
+  foodTruckId?: number;
+  /**
+   * 푸드트럭 이미지
+   * @example "image.png"
+   */
+  imageUrl?: string;
+  /**
+   * 푸드트럭 이름
+   * @example "차콜 푸드트럭"
+   */
+  name?: string;
+  /**
+   * 푸드트럭 설명
+   * @example "저희 푸드트럭은 10년간 이어져온..."
+   */
+  description?: string;
+  /**
+   * 운영 가능 시간대
+   * @example "09:00 ~ 21:00"
+   */
+  activeTime?: string;
+  /**
+   * 호출 가능 지역
+   * @example "서울 전체, 경기도 수원시 영통구, 인천 계양구"
+   */
+  serviceArea?: string;
+}
+
+export interface BaseResponseListChatTemplateResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: ChatTemplateResponse[];
+}
+
+export interface ChatTemplateResponse {
+  /**
+   * 자주 쓰는 채팅 식별자
+   * @format int64
+   * @example 1
+   */
+  chatTemplateId?: number;
+  /**
+   * 자주 쓰는 채팅 내용
+   * @example "안녕하세요. 차콜 푸드트럭입니다!"
+   */
+  content?: string;
+}
+
+export interface BankAccountResponse {
+  /**
+   * 계좌 식별자
+   * @format int64
+   * @example 1
+   */
+  bankAccountId?: number;
+  /**
+   * 은행명
+   * @example "기업은행"
+   */
+  bankName?: string;
+  /**
+   * 예금주명
+   * @example "홍길동"
+   */
+  accountHolderName?: string;
+  /**
+   * 계좌번호
+   * @example "110-1123-123124"
+   */
+  accountNumber?: string;
+}
+
+export interface BaseResponseBankAccountResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: BankAccountResponse;
+}
+
+export interface BaseResponseCursorPagingResponseMemberReservationHistoryResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: CursorPagingResponseMemberReservationHistoryResponse;
+}
+
+export interface CursorPagingResponseMemberReservationHistoryResponse {
+  content?: MemberReservationHistoryResponse[];
+  /** @format int64 */
+  lastCursor?: number;
+  hasNext?: boolean;
+}
+
+export interface MemberReservationHistoryResponse {
+  /**
+   * 예약 내역 식별자
+   * @format int64
+   * @example 1
+   */
+  reservationId?: number;
+  /**
+   * 푸드트럭 대표 사진 URL
+   * @example "https://example.com/foodtruck.jpg"
+   */
+  photoUrl?: string;
+  /**
+   * 푸드트럭 이름
+   * @example "맛있는 푸드트럭"
+   */
+  name?: string;
+  /**
+   * 예약 주소
+   * @example "서울 광진구 화양동"
+   */
+  address?: string;
+  /**
+   * 예약 날짜 및 운영 시간 정보 리스트 (최대 2개)
+   * @example ["2025-09-20 13시~19시","2025-09-21 13시~19시"]
+   */
+  dateTimeInfos?: string[];
+}
+
+export interface BaseResponseMemberReservationDetailResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: MemberReservationDetailResponse;
+}
+
+export interface MemberReservationDetailResponse {
+  /**
+   * 푸드트럭의 대표 사진 URL
+   * @example "https://example.com/foodtruck.jpg"
+   */
+  photoUrl?: string;
+  /**
+   * 푸드트럭 이름
+   * @example "맛있는 푸드트럭"
+   */
+  name?: string;
+  /**
+   * 예약 주소
+   * @example "서울 광진구 화양동 123-45"
+   */
+  address?: string;
+  /**
+   * 예약 날짜 및 운영 시간 정보 리스트 (최대 2개)
+   * @example ["2025-09-20 13시~19시","2025-09-21 13시~19시"]
+   */
+  dateTimeInfos?: string[];
+  /**
+   * 견적서 PDF 다운로드 URL (null 일 수 있음)
+   * @example "https://storage.url/quotes/reservation_123.pdf"
+   */
+  pdfUrl?: string;
+  /**
+   * 운영 메뉴
+   * @example "핫도그, 국밥, 짜장면"
+   */
+  menu?: string;
+  /**
+   * 지불된 예약금액
+   * @example "50000원"
+   */
+  deposit?: string;
+  /**
+   * 전기 사용 가능 여부
+   * @example "가능"
+   */
+  electricityInfo?: string;
+  /**
+   * 기타 요청 사항 (null 일 수 있음)
+   * @example "음식을 많이 주세요, 늦지말아주세요"
+   */
+  etcRequest?: string;
+}
+
+export interface BaseResponseReservationForRatingResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: ReservationForRatingResponse;
+}
+
+export interface ReservationForRating {
+  /**
+   * 예약 식별자
+   * @format int64
+   * @example 1
+   */
+  reservationId?: number;
+  /**
+   * 푸드트럭 식별자
+   * @format int64
+   * @example 1
+   */
+  foodTruckId?: number;
+  /**
+   * 푸드트럭 이름
+   * @example "푸드트럭"
+   */
+  name?: string;
+  /**
+   * 푸드트럭 대표 사진 URL
+   * @example "http://image.png"
+   */
+  photoUrl?: string;
+  /**
+   * 예약 주소
+   * @example "서울 광진구 화양동"
+   */
+  address?: string;
+  /**
+   * 예약 날짜 및 운영 시간 정보 리스트 (최대 2개)
+   * @example ["2025-09-20 13시~19시","2025-09-21 13시~19시"]
+   */
+  dateTimeInfos?: string[];
+}
+
+export interface ReservationForRatingResponse {
+  /** 평점 등록이 필요한 예약 리스트 */
+  reservations?: ReservationForRating[];
+}
+
+export interface BaseResponseCursorPagingResponseSavedFoodTruckResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: CursorPagingResponseSavedFoodTruckResponse;
+}
+
+export interface CursorPagingResponseSavedFoodTruckResponse {
+  content?: SavedFoodTruckResponse[];
+  /** @format int64 */
+  lastCursor?: number;
+  hasNext?: boolean;
+}
+
+export interface SavedFoodTruckResponse {
+  /**
+   * 푸드트럭 식별자
+   * @format int64
+   * @example 1
+   */
+  foodTruckId?: number;
+  /**
+   * 푸드트럭 이름
+   * @example "푸드트럭"
+   */
+  name?: string;
+  /**
+   * 푸드트럭 대표 사진 URL
+   * @example "http://image.png"
+   */
+  photoUrl?: string;
+  /**
+   * 푸드트럭 설명
+   * @example "맛있는 푸드트럭입니다."
+   */
+  description?: string;
+  /**
+   * 푸드트럭 평균 평점
+   * @format double
+   * @example 4.5
+   */
+  averageRating?: number;
+  /**
+   * 푸드트럭 평점 수
+   * @format int32
+   * @example 100
+   */
+  ratingCount?: number;
+}
+
+export type GetUserInfoData = BaseResponseUserResponse;
+
+export type UpdateUserInfoData = BaseResponseVoid;
+
+export type GetReservationData = BaseResponseReservationResponse;
+
+export type UpdateReservationData = BaseResponseReservationIdResponse;
+
+export type UpdateChatTemplateData = BaseResponseVoid;
+
+export type DeleteChatTemplateData = BaseResponseVoid;
+
+export type UpdateBankAccountData = BaseResponseVoid;
+
+export type DeleteBankAccountData = BaseResponseVoid;
+
+export type CreateReservationData = BaseResponseReservationIdResponse;
+
+export type GetChatTemplatesData = BaseResponseListChatTemplateResponse;
+
+export type RegisterChatTemplateData = BaseResponseVoid;
+
+export type GetBankAccountData = BaseResponseBankAccountResponse;
+
+export type RegisterBankAccountData = BaseResponseVoid;
+
+export type RegisterRatingsData = BaseResponseVoid;
+
+export type GetTokenData = BaseResponseAuthTokenResponse;
+
+export type UpdateFoodTruckSaveStatusData =
+  BaseResponseSavedFoodTruckStatusResponse;
+
+export type GetRegionsData = BaseResponseListRegionResponse;
+
+export type SearchRegionsData = BaseResponseListRegionResponse;
+
+export type GetOwnerReservationsData =
+  BaseResponseCursorPagingResponseOwnerReservationHistoryResponse;
+
+export type GetReservationDetailData =
+  BaseResponseOwnerReservationDetailResponse;
+
+export type GetMyFoodTrucksData =
+  BaseResponseCursorPagingResponseMyFoodTruckResponse;
+
+export type GetMemberReservationsData =
+  BaseResponseCursorPagingResponseMemberReservationHistoryResponse;
+
+export type GetMemberReservationDetailData =
+  BaseResponseMemberReservationDetailResponse;
+
+export type GetReservationsForRatingData =
+  BaseResponseReservationForRatingResponse;
+
+export type GetSavedFoodTrucksData =
+  BaseResponseCursorPagingResponseSavedFoodTruckResponse;
+
+export type DeleteFoodTruckData = BaseResponseVoid;

--- a/apis/http-client.ts
+++ b/apis/http-client.ts
@@ -1,0 +1,186 @@
+/* eslint-disable */
+/* tslint:disable */
+// @ts-nocheck
+/*
+ * ---------------------------------------------------------------
+ * ## THIS FILE WAS GENERATED VIA SWAGGER-TYPESCRIPT-API        ##
+ * ##                                                           ##
+ * ## AUTHOR: acacode                                           ##
+ * ## SOURCE: https://github.com/acacode/swagger-typescript-api ##
+ * ---------------------------------------------------------------
+ */
+
+import type {
+  AxiosInstance,
+  AxiosRequestConfig,
+  AxiosResponse,
+  HeadersDefaults,
+  ResponseType,
+} from "axios";
+import axios from "axios";
+
+export type QueryParamsType = Record<string | number, any>;
+
+export interface FullRequestParams
+  extends Omit<AxiosRequestConfig, "data" | "params" | "url" | "responseType"> {
+  /** set parameter to `true` for call `securityWorker` for this request */
+  secure?: boolean;
+  /** request path */
+  path: string;
+  /** content type of request body */
+  type?: ContentType;
+  /** query params */
+  query?: QueryParamsType;
+  /** format of response (i.e. response.json() -> format: "json") */
+  format?: ResponseType;
+  /** request body */
+  body?: unknown;
+}
+
+export type RequestParams = Omit<
+  FullRequestParams,
+  "body" | "method" | "query" | "path"
+>;
+
+export interface ApiConfig<SecurityDataType = unknown>
+  extends Omit<AxiosRequestConfig, "data" | "cancelToken"> {
+  securityWorker?: (
+    securityData: SecurityDataType | null,
+  ) => Promise<AxiosRequestConfig | void> | AxiosRequestConfig | void;
+  secure?: boolean;
+  format?: ResponseType;
+}
+
+export enum ContentType {
+  Json = "application/json",
+  JsonApi = "application/vnd.api+json",
+  FormData = "multipart/form-data",
+  UrlEncoded = "application/x-www-form-urlencoded",
+  Text = "text/plain",
+}
+
+export class HttpClient<SecurityDataType = unknown> {
+  public instance: AxiosInstance;
+  private securityData: SecurityDataType | null = null;
+  private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
+  private secure?: boolean;
+  private format?: ResponseType;
+
+  constructor({
+    securityWorker,
+    secure,
+    format,
+    ...axiosConfig
+  }: ApiConfig<SecurityDataType> = {}) {
+    this.instance = axios.create({
+      ...axiosConfig,
+      baseURL: axiosConfig.baseURL || "http://52.79.221.101:8000",
+    });
+    this.secure = secure;
+    this.format = format;
+    this.securityWorker = securityWorker;
+  }
+
+  public setSecurityData = (data: SecurityDataType | null) => {
+    this.securityData = data;
+  };
+
+  protected mergeRequestParams(
+    params1: AxiosRequestConfig,
+    params2?: AxiosRequestConfig,
+  ): AxiosRequestConfig {
+    const method = params1.method || (params2 && params2.method);
+
+    return {
+      ...this.instance.defaults,
+      ...params1,
+      ...(params2 || {}),
+      headers: {
+        ...((method &&
+          this.instance.defaults.headers[
+            method.toLowerCase() as keyof HeadersDefaults
+          ]) ||
+          {}),
+        ...(params1.headers || {}),
+        ...((params2 && params2.headers) || {}),
+      },
+    };
+  }
+
+  protected stringifyFormItem(formItem: unknown) {
+    if (typeof formItem === "object" && formItem !== null) {
+      return JSON.stringify(formItem);
+    } else {
+      return `${formItem}`;
+    }
+  }
+
+  protected createFormData(input: Record<string, unknown>): FormData {
+    if (input instanceof FormData) {
+      return input;
+    }
+    return Object.keys(input || {}).reduce((formData, key) => {
+      const property = input[key];
+      const propertyContent: any[] =
+        property instanceof Array ? property : [property];
+
+      for (const formItem of propertyContent) {
+        const isFileType = formItem instanceof Blob || formItem instanceof File;
+        formData.append(
+          key,
+          isFileType ? formItem : this.stringifyFormItem(formItem),
+        );
+      }
+
+      return formData;
+    }, new FormData());
+  }
+
+  public request = async <T = any, _E = any>({
+    secure,
+    path,
+    type,
+    query,
+    format,
+    body,
+    ...params
+  }: FullRequestParams): Promise<AxiosResponse<T>> => {
+    const secureParams =
+      ((typeof secure === "boolean" ? secure : this.secure) &&
+        this.securityWorker &&
+        (await this.securityWorker(this.securityData))) ||
+      {};
+    const requestParams = this.mergeRequestParams(params, secureParams);
+    const responseFormat = format || this.format || undefined;
+
+    if (
+      type === ContentType.FormData &&
+      body &&
+      body !== null &&
+      typeof body === "object"
+    ) {
+      body = this.createFormData(body as Record<string, unknown>);
+    }
+
+    if (
+      type === ContentType.Text &&
+      body &&
+      body !== null &&
+      typeof body !== "string"
+    ) {
+      body = JSON.stringify(body);
+    }
+
+    return this.instance.request({
+      ...requestParams,
+      headers: {
+        ...(requestParams.headers || {}),
+        ...(type ? { "Content-Type": type } : {}),
+      },
+      params: query,
+      responseType: responseFormat,
+      data: body,
+      url: path,
+    });
+  };
+}

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "fix-all": "pnpm type-check && pnpm lint:fix && pnpm format",
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "chromatic": "npx chromatic --project-token=chpt_b45a4ae4e58f49f"
+    "chromatic": "npx chromatic --project-token=chpt_b45a4ae4e58f49f",
+    "swagger-typescript-api": "swagger-typescript-api generate -p http://52.79.221.101:8000/v3/api-docs -r -o ./apis --modular -d --extract-request-body --extract-response-body --extract-response-error --axios --clean-output"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.1",
@@ -64,6 +65,7 @@
     "prettier": "^3.6.2",
     "prettier-plugin-tailwindcss": "^0.6.14",
     "storybook": "9.1.3",
+    "swagger-typescript-api": "13.2.7",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
     "vite": "^7.1.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,7 +13,7 @@ importers:
         version: 5.2.1(react-hook-form@7.62.0(react@19.1.1))
       '@tailwindcss/vite':
         specifier: ^4.1.12
-        version: 4.1.13(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 4.1.13(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@tanstack/react-query':
         specifier: ^5.85.6
         version: 5.87.4(react@19.1.1)
@@ -53,22 +53,22 @@ importers:
     devDependencies:
       '@chromatic-com/storybook':
         specifier: 4.1.1
-        version: 4.1.1(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+        version: 4.1.1(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       '@eslint/js':
         specifier: ^9.33.0
         version: 9.35.0
       '@storybook/addon-a11y':
         specifier: 9.1.3
-        version: 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+        version: 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       '@storybook/addon-docs':
         specifier: 9.1.3
-        version: 9.1.3(@types/react@19.1.13)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+        version: 9.1.3(@types/react@19.1.13)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       '@storybook/addon-vitest':
         specifier: 9.1.3
-        version: 9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(vitest@3.2.4)
+        version: 9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(vitest@3.2.4)
       '@storybook/react-vite':
         specifier: 9.1.3
-        version: 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@tailwindcss/postcss':
         specifier: ^4.1.12
         version: 4.1.13
@@ -89,10 +89,10 @@ importers:
         version: 19.1.9(@types/react@19.1.13)
       '@vitejs/plugin-react':
         specifier: ^5.0.0
-        version: 5.0.2(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 5.0.2(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@vitest/browser':
         specifier: ^3.2.4
-        version: 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+        version: 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))(vitest@3.2.4)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(@vitest/browser@3.2.4)(vitest@3.2.4)
@@ -122,7 +122,7 @@ importers:
         version: 0.4.20(eslint@9.35.0(jiti@2.5.1))
       eslint-plugin-storybook:
         specifier: 9.1.3
-        version: 9.1.3(eslint@9.35.0(jiti@2.5.1))(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3)
+        version: 9.1.3(eslint@9.35.0(jiti@2.5.1))(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3)
       globals:
         specifier: ^16.3.0
         version: 16.4.0
@@ -137,7 +137,10 @@ importers:
         version: 0.6.14(prettier@3.6.2)
       storybook:
         specifier: 9.1.3
-        version: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
+      swagger-typescript-api:
+        specifier: 13.2.7
+        version: 13.2.7(magicast@0.3.5)
       typescript:
         specifier: ~5.8.3
         version: 5.8.3
@@ -146,13 +149,13 @@ importers:
         version: 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       vite:
         specifier: ^7.1.2
-        version: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+        version: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
       vite-plugin-svgr:
         specifier: ^4.5.0
-        version: 4.5.0(rollup@4.50.1)(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 4.5.0(rollup@4.50.1)(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+        version: 5.1.4(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
 
 packages:
 
@@ -257,6 +260,23 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@biomejs/js-api@1.0.0':
+    resolution: {integrity: sha512-69OfQ7+09AtiCIg+k+aU3rEsGit5o/SJWCS3BeBH/2nJYdJGi0cIx+ybka8i1EK69aNcZxYO1y1iAAEmYMq1HA==}
+    peerDependencies:
+      '@biomejs/wasm-bundler': ^2.0.0
+      '@biomejs/wasm-nodejs': ^2.0.0
+      '@biomejs/wasm-web': ^2.0.0
+    peerDependenciesMeta:
+      '@biomejs/wasm-bundler':
+        optional: true
+      '@biomejs/wasm-nodejs':
+        optional: true
+      '@biomejs/wasm-web':
+        optional: true
+
+  '@biomejs/wasm-nodejs@2.0.5':
+    resolution: {integrity: sha512-pihpBMylewgDdGFZHRkgmc3OajuGIJPXhvfYuKCNK/CWyJMrYEFmPKs8Iq1kY0sYMmGlTbD4K2udV03KYa+r0Q==}
 
   '@chromatic-com/storybook@4.1.1':
     resolution: {integrity: sha512-+Ib4cHtEjKl/Do+4LyU0U1FhLPbIU2Q/zgbOKHBCV+dTC4T3/vGzPqiGsgkdnZyTsK/zXg96LMPSPC4jjOiapg==}
@@ -466,6 +486,9 @@ packages:
   '@eslint/plugin-kit@0.3.5':
     resolution: {integrity: sha512-Z5kJ+wU3oA7MMIqVR9tyZRtjYPr4OC004Q4Rw7pgOKUOKkJfZ3O24nz3WYfGRpMDNmcOi3TwQOmgm7B7Tpii0w==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@exodus/schemasafe@1.3.0':
+    resolution: {integrity: sha512-5Aap/GaRupgNx/feGBwLLTVv8OQFfv3pq2lPRzPg9R+IOBnDgghTGW7l7EuVXOvg5cc/xSAlRW8rBrjIC3Nvqw==}
 
   '@hookform/resolvers@5.2.1':
     resolution: {integrity: sha512-u0+6X58gkjMcxur1wRWokA7XsiiBJ6aK17aPZxhkoYiK5J+HcTx0Vhu9ovXe6H+dVpO6cjrn2FkJTryXEMlryQ==}
@@ -997,6 +1020,9 @@ packages:
   '@types/resolve@1.20.6':
     resolution: {integrity: sha512-A4STmOXPhMUtHH+S6ymgE2GiBSMqf4oTvcQZMcHzokuTLVYzXTB8ttjcgxOVaAp2lGwEdzZ0J+cRbbeevQj1UQ==}
 
+  '@types/swagger-schema-official@2.0.25':
+    resolution: {integrity: sha512-T92Xav+Gf/Ik1uPW581nA+JftmjWPgskw/WBf4TJzxRG/SJ+DfNnNE+WuZ4mrXuzflQMqMkm1LSYjzYW7MB1Cg==}
+
   '@typescript-eslint/eslint-plugin@8.43.0':
     resolution: {integrity: sha512-8tg+gt7ENL7KewsKMKDHXR1vm8tt9eMxjJBYINf6swonlWgkYn5NwyIgXpbbDxTNU5DgpDFfj95prcTq2clIQQ==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -1333,6 +1359,14 @@ packages:
     engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
     hasBin: true
 
+  c12@3.3.0:
+    resolution: {integrity: sha512-K9ZkuyeJQeqLEyqldbYLG3wjqwpw4BVaAqvmxq3GYKK0b1A/yYQdIcJxkzAOWcNVWhJpRXAPfZFueekiY/L8Dw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
     engines: {node: '>=8'}
@@ -1348,6 +1382,9 @@ packages:
   call-bound@1.0.4:
     resolution: {integrity: sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==}
     engines: {node: '>= 0.4'}
+
+  call-me-maybe@1.0.2:
+    resolution: {integrity: sha512-HpX65o1Hnr9HH25ojC1YGs7HCQLq0GCOibSaWER0eNpgJ/Z1MZv2mTc7+xh6WOPxbRVcmgbv4hGU+uSQ/2xFZQ==}
 
   callsites@3.1.0:
     resolution: {integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==}
@@ -1371,6 +1408,10 @@ packages:
   check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
 
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
@@ -1400,8 +1441,15 @@ packages:
       '@chromatic-com/playwright':
         optional: true
 
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  cliui@8.0.1:
+    resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
+    engines: {node: '>=12'}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -1416,6 +1464,13 @@ packages:
 
   concat-map@0.0.1:
     resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+
+  confbox@0.2.2:
+    resolution: {integrity: sha512-1NB+BKqhtNipMsov4xI/NnhCKp9XG9NamYp5PVm9klAT0fsrNPjaFICsCFhNhwZJKNh7zB/3q8qXz0E9oaMNtQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
@@ -1491,9 +1546,15 @@ packages:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
 
+  defu@6.1.4:
+    resolution: {integrity: sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
 
   detect-libc@2.0.4:
     resolution: {integrity: sha512-3UDv+G9CsCKO1WKMGw9fwq/SWJYbI0c5Y7LU1AXYoDdbhE2AHQ6N6Nb34sG8Fj7T5APy8qXDCKuuIHd1BR0tVA==}
@@ -1515,6 +1576,10 @@ packages:
 
   dot-case@3.0.4:
     resolution: {integrity: sha512-Kv5nKlh6yRrdrGvxeJ2e5y2eRUpkUosIW4A2AS38zwSz27zu7ufDwQPi5Jhs3XAlGNetl3bmnGhQsMtkKJnj3w==}
+
+  dotenv@17.2.2:
+    resolution: {integrity: sha512-Sf2LSQP+bOlhKWWyhFsn0UsfdK/kCWRv1iuA2gXAwt3dyNabr6QSj00I2V10pidqz69soatm9ZwZvpQMTIOd5Q==}
+    engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -1573,6 +1638,9 @@ packages:
   es-to-primitive@1.3.0:
     resolution: {integrity: sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g==}
     engines: {node: '>= 0.4'}
+
+  es6-promise@3.3.1:
+    resolution: {integrity: sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==}
 
   esbuild-register@3.6.0:
     resolution: {integrity: sha512-H2/S7Pm8a9CL1uhp9OvjwrBh5Pvx0H8qVOxNu8Wed9Y7qv56MPtq+GGM8RJpq6glYJn9Wspr8uw7l55uyinNeg==}
@@ -1725,9 +1793,16 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eta@2.2.0:
+    resolution: {integrity: sha512-UVQ72Rqjy/ZKQalzV5dCCJP80GrmPrMxh6NlNf+erV6ObL0ZFkhCstWRawS85z3smdr3d2wXPsZEY7rDPfGd2g==}
+    engines: {node: '>=6.0.0'}
+
   expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
+
+  exsolve@1.0.7:
+    resolution: {integrity: sha512-VO5fQUzZtI6C+vx4w/4BWJpg3s/5l+6pRQEHzFRM8WFi4XffSP1Z+4qi7GbjWbvRQEbdIco5mIMq+zX4rPuLrw==}
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -1741,6 +1816,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-safe-stringify@2.1.1:
+    resolution: {integrity: sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==}
 
   fastq@1.19.1:
     resolution: {integrity: sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==}
@@ -1816,6 +1894,10 @@ packages:
     resolution: {integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==}
     engines: {node: '>=6.9.0'}
 
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
   get-intrinsic@1.3.0:
     resolution: {integrity: sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==}
     engines: {node: '>= 0.4'}
@@ -1830,6 +1912,10 @@ packages:
 
   get-tsconfig@4.10.1:
     resolution: {integrity: sha512-auHyJ4AgMz7vgS8Hp3N6HXSmlMdUyhSUrfBF16w153rxtLIEOE+HGqaBppczZvnHLqQJfiHotCYpNhl0lUROFQ==}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
 
   glob-parent@5.1.2:
     resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
@@ -1897,6 +1983,9 @@ packages:
 
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
+
+  http2-client@1.3.5:
+    resolution: {integrity: sha512-EC2utToWl4RKfs5zd36Mxq7nzHHBuomZboI0yYL6Y0RmBgT7Sgkq4rQ0ezFTYoIsSs7Tm9SJe+o2FcAg6GBhGA==}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -2278,6 +2367,11 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  nanoid@5.1.5:
+    resolution: {integrity: sha512-Ir/+ZpE9fDsNH0hQ3C68uyThDXzYcim2EqcZ8zn8Chtt1iylPT9xXJB0kPCnqzgcEGikO9RxSrh63MsmVCU7Fw==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
   napi-postinstall@0.3.3:
     resolution: {integrity: sha512-uTp172LLXSxuSYHv/kou+f6KW3SMppU9ivthaVTXian9sOt3XM/zHYHpRZiLgQoxeWfYUnslNWQHF1+G71xcow==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2289,12 +2383,52 @@ packages:
   no-case@3.0.4:
     resolution: {integrity: sha512-fgAN3jGAh+RoxUGZHTSOLJIqUc2wmoBwGR4tbpNAKmmovFoWq0OdRkb0VkldReO2a2iBT/OEulG9XSUc10r3zg==}
 
+  node-fetch-h2@2.3.0:
+    resolution: {integrity: sha512-ofRW94Ab0T4AOh5Fk8t0h8OBWrmjb0SSB20xh1H8YnPV9EJ+f5AMoYSUQ2zgJ4Iq2HAK0I2l5/Nequ8YzFS3Hg==}
+    engines: {node: 4.x || >=6.0.0}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-fetch@2.7.0:
+    resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
+    engines: {node: 4.x || >=6.0.0}
+    peerDependencies:
+      encoding: ^0.1.0
+    peerDependenciesMeta:
+      encoding:
+        optional: true
+
+  node-readfiles@0.2.0:
+    resolution: {integrity: sha512-SU00ZarexNlE4Rjdm83vglt5Y9yiQ+XI1XpflWlb7q7UTN1JUItm69xMeiQCTxtTfnzt+83T8Cx+vI2ED++VDA==}
+
   node-releases@2.0.21:
     resolution: {integrity: sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==}
 
   normalize-range@0.1.2:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
+
+  nypm@0.6.2:
+    resolution: {integrity: sha512-7eM+hpOtrKrBDCh7Ypu2lJ9Z7PNZBdi/8AT3AX8xoCj43BBVHD0hPSTEvMtkMpfs8FCqBGhxB+uToIQimA111g==}
+    engines: {node: ^14.16.0 || >=16.10.0}
+    hasBin: true
+
+  oas-kit-common@1.0.8:
+    resolution: {integrity: sha512-pJTS2+T0oGIwgjGpw7sIRU8RQMcUoKCDWFLdBqKB2BNmGpbBMH2sdqAaOXUg8OzonZHU0L7vfJu1mJFEiYDWOQ==}
+
+  oas-linter@3.2.2:
+    resolution: {integrity: sha512-KEGjPDVoU5K6swgo9hJVA/qYGlwfbFx+Kg2QB/kd7rzV5N8N5Mg6PlsoCMohVnQmo+pzJap/F610qTodKzecGQ==}
+
+  oas-resolver@2.5.6:
+    resolution: {integrity: sha512-Yx5PWQNZomfEhPPOphFbZKi9W93CocQj18NlD2Pa4GWZzdZpSJvYwoiuurRI7m3SpcChrnO08hkuQDL3FGsVFQ==}
+    hasBin: true
+
+  oas-schema-walker@1.1.5:
+    resolution: {integrity: sha512-2yucenq1a9YPmeNExoUa9Qwrt9RFkjqaMAA1X+U7sbb0AqBeTIdMHky9SQQ6iN94bO5NW0W4TRYXerG+BdAvAQ==}
+
+  oas-validator@5.0.8:
+    resolution: {integrity: sha512-cu20/HE5N5HKqVygs3dt94eYJfBi0TsZvPVXDhbXQHiEityDN+RROTleefoKRKKJ9dFAF2JBkDHgvWj0sjKGmw==}
 
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
@@ -2319,6 +2453,9 @@ packages:
   object.values@1.2.1:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
 
   open@8.4.2:
     resolution: {integrity: sha512-7x81NCL719oNbsq/3mh+hVrAWmFuEYUqrq/Iw3kUzH8ReypT9QQ0BLoJS7/G9k6N81XjW4qHWtjWwe/9eLy1EQ==}
@@ -2389,6 +2526,9 @@ packages:
     resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
     engines: {node: '>= 14.16'}
 
+  perfect-debounce@2.0.0:
+    resolution: {integrity: sha512-fkEH/OBiKrqqI/yIgjR92lMfs2K8105zt/VT6+7eTjNwisrsh47CeIED9z58zI7DfKdH3uHAn25ziRZn3kgAow==}
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -2399,6 +2539,9 @@ packages:
   picomatch@4.0.3:
     resolution: {integrity: sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==}
     engines: {node: '>=12'}
+
+  pkg-types@2.3.0:
+    resolution: {integrity: sha512-SIqCzDRg0s9npO5XQ3tNZioRY1uK06lA41ynBC1YmFTmnY6FjUjVt6s4LoADmwoig1qqD0oK8h1p/8mlMx8Oig==}
 
   playwright-core@1.55.0:
     resolution: {integrity: sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==}
@@ -2506,6 +2649,9 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
     peerDependencies:
@@ -2560,6 +2706,10 @@ packages:
     resolution: {integrity: sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==}
     engines: {node: '>=0.10.0'}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
   recast@0.23.11:
     resolution: {integrity: sha512-YTUo+Flmw4ZXiWfQKGcwwc11KnoRAYgzAE2E7mXKCjSviTKShtxBsN6YUUBB2gtaBzKzeKunxhUwNHQuRryhWA==}
     engines: {node: '>= 4'}
@@ -2572,9 +2722,16 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  reftools@1.1.9:
+    resolution: {integrity: sha512-OVede/NQE13xBQ+ob5CKd5KyeJYU2YInb1bmV4nRoOfquZPkAkxuOXicSe1PvqIuZZ4kD13sPKBbR7UFDmli6w==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2646,6 +2803,24 @@ packages:
   shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
+
+  should-equal@2.0.0:
+    resolution: {integrity: sha512-ZP36TMrK9euEuWQYBig9W55WPC7uo37qzAEmbjHz4gfyuXrEUgF8cUvQVO+w+d3OMfPvSRQJ22lSm8MQJ43LTA==}
+
+  should-format@3.0.3:
+    resolution: {integrity: sha512-hZ58adtulAk0gKtua7QxevgUaXTTXxIi8t41L3zo9AHvjXO1/7sdLECuHeIN2SRtYXpNkmhoUP2pdeWgricQ+Q==}
+
+  should-type-adaptors@1.1.0:
+    resolution: {integrity: sha512-JA4hdoLnN+kebEp2Vs8eBe9g7uy0zbRo+RMcU0EsNy+R+k049Ki+N5tT5Jagst2g7EAja+euFuoXFCa8vIklfA==}
+
+  should-type@1.4.0:
+    resolution: {integrity: sha512-MdAsTu3n25yDbIe1NeN69G4n6mUnJGtSJHygX3+oN0ZbO3DTiATnf7XnYJdGT42JCXurTb1JI0qOBR65shvhPQ==}
+
+  should-util@1.0.1:
+    resolution: {integrity: sha512-oXF8tfxx5cDk8r2kYqlkUJzZpDBqVY/II2WhvU0n9Y3XYvAYRmeaf1PvvIvTgPnv4KJ+ES5M0PyDq5Jp+Ygy2g==}
+
+  should@13.2.3:
+    resolution: {integrity: sha512-ggLesLtu2xp+ZxI+ysJTmNjh2U0TsC+rQ/pfED9bUZZ4DKefP27D+7YJVVTvKsmjLpIi9jAa7itwDGkDDmt1GQ==}
 
   side-channel-list@1.0.0:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
@@ -2769,6 +2944,18 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
+  swagger-schema-official@2.0.0-bab6bed:
+    resolution: {integrity: sha512-rCC0NWGKr/IJhtRuPq/t37qvZHI/mH4I4sxflVM+qgVe5Z2uOCivzWaVbuioJaB61kvm5UvB7b49E+oBY0M8jA==}
+
+  swagger-typescript-api@13.2.7:
+    resolution: {integrity: sha512-rfqqoRFpZJPl477M/snMJPM90EvI8WqhuUHSF5ecC2r/w376T29+QXNJFVPsJmbFu5rBc/8m3vhArtMctjONdw==}
+    engines: {node: '>=20'}
+    hasBin: true
+
+  swagger2openapi@7.0.8:
+    resolution: {integrity: sha512-upi/0ZGkYgEcLeGieoz8gT74oWHA0E7JivX7aN9mAf+Tc7BQoRBvnIGHoPDw+f9TXTW4s6kGYCZJtauP6OYp7g==}
+    hasBin: true
+
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
@@ -2796,6 +2983,9 @@ packages:
   tinyexec@0.3.2:
     resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
 
+  tinyexec@1.0.1:
+    resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
+
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
@@ -2819,6 +3009,9 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tr46@0.0.3:
+    resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   ts-api-utils@2.1.0:
     resolution: {integrity: sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==}
@@ -2999,8 +3192,14 @@ packages:
       jsdom:
         optional: true
 
+  webidl-conversions@3.0.1:
+    resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-url@5.0.0:
+    resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -3052,12 +3251,33 @@ packages:
       utf-8-validate:
         optional: true
 
+  y18n@5.0.8:
+    resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
+    engines: {node: '>=10'}
+
   yallist@3.1.1:
     resolution: {integrity: sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==}
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
     engines: {node: '>=18'}
+
+  yaml@1.10.2:
+    resolution: {integrity: sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==}
+    engines: {node: '>= 6'}
+
+  yaml@2.8.1:
+    resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@21.1.1:
+    resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
+    engines: {node: '>=12'}
+
+  yargs@17.7.2:
+    resolution: {integrity: sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==}
+    engines: {node: '>=12'}
 
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
@@ -3215,13 +3435,19 @@ snapshots:
 
   '@bcoe/v8-coverage@1.0.2': {}
 
-  '@chromatic-com/storybook@4.1.1(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))':
+  '@biomejs/js-api@1.0.0(@biomejs/wasm-nodejs@2.0.5)':
+    optionalDependencies:
+      '@biomejs/wasm-nodejs': 2.0.5
+
+  '@biomejs/wasm-nodejs@2.0.5': {}
+
+  '@chromatic-com/storybook@4.1.1(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))':
     dependencies:
       '@neoconfetti/react': 1.0.0
       chromatic: 12.2.0
       filesize: 10.1.6
       jsonfile: 6.2.0
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       strip-ansi: 7.1.2
     transitivePeerDependencies:
       - '@chromatic-com/cypress'
@@ -3365,6 +3591,8 @@ snapshots:
       '@eslint/core': 0.15.2
       levn: 0.4.1
 
+  '@exodus/schemasafe@1.3.0': {}
+
   '@hookform/resolvers@5.2.1(react-hook-form@7.62.0(react@19.1.1))':
     dependencies:
       '@standard-schema/utils': 0.3.0
@@ -3396,12 +3624,12 @@ snapshots:
 
   '@istanbuljs/schema@0.1.3': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.19
       react-docgen-typescript: 2.4.0(typescript@5.8.3)
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     optionalDependencies:
       typescript: 5.8.3
 
@@ -3533,50 +3761,50 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))':
+  '@storybook/addon-a11y@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
 
-  '@storybook/addon-docs@9.1.3(@types/react@19.1.13)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))':
+  '@storybook/addon-docs@9.1.3(@types/react@19.1.13)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))':
     dependencies:
       '@mdx-js/react': 3.1.1(@types/react@19.1.13)(react@19.1.1)
-      '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+      '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
-      '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+      '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-vitest@9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(vitest@3.2.4)':
+  '@storybook/addon-vitest@9.1.3(@vitest/browser@3.2.4)(@vitest/runner@3.2.4)(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(vitest@3.2.4)':
     dependencies:
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.4.0(react-dom@19.1.1(react@19.1.1))(react@19.1.1)
       prompts: 2.4.2
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))(vitest@3.2.4)
       '@vitest/runner': 3.2.4
-      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)
+      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - react
       - react-dom
 
-  '@storybook/builder-vite@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@storybook/builder-vite@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@storybook/csf-plugin': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       ts-dedent: 2.2.0
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
-  '@storybook/csf-plugin@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))':
+  '@storybook/csf-plugin@9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))':
     dependencies:
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -3586,39 +3814,39 @@ snapshots:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
 
-  '@storybook/react-dom-shim@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))':
+  '@storybook/react-dom-shim@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))':
     dependencies:
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
 
-  '@storybook/react-vite@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@storybook/react-vite@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(rollup@4.50.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
-      '@storybook/builder-vite': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
-      '@storybook/react': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3)
+      '@storybook/builder-vite': 9.1.3(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
+      '@storybook/react': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3)
       find-up: 7.0.0
       magic-string: 0.30.19
       react: 19.1.1
       react-docgen: 8.0.1
       react-dom: 19.1.1(react@19.1.1)
       resolve: 1.22.10
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       tsconfig-paths: 4.2.0
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3)':
+  '@storybook/react@9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))
+      '@storybook/react-dom-shim': 9.1.3(react-dom@19.1.1(react@19.1.1))(react@19.1.1)(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))
       react: 19.1.1
       react-dom: 19.1.1(react@19.1.1)
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
     optionalDependencies:
       typescript: 5.8.3
 
@@ -3764,12 +3992,12 @@ snapshots:
       postcss: 8.5.6
       tailwindcss: 4.1.13
 
-  '@tailwindcss/vite@4.1.13(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@tailwindcss/vite@4.1.13(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       '@tailwindcss/node': 4.1.13
       '@tailwindcss/oxide': 4.1.13
       tailwindcss: 4.1.13
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
   '@tanstack/eslint-plugin-query@5.86.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
@@ -3869,6 +4097,8 @@ snapshots:
       csstype: 3.1.3
 
   '@types/resolve@1.20.6': {}
+
+  '@types/swagger-schema-official@2.0.25': {}
 
   '@typescript-eslint/eslint-plugin@8.43.0(@typescript-eslint/parser@8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3))(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)':
     dependencies:
@@ -4022,7 +4252,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react@5.0.2(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@vitejs/plugin-react@5.0.2(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       '@babel/core': 7.28.4
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.28.4)
@@ -4030,20 +4260,20 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-beta.34
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
 
-  '@vitest/browser@3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)':
+  '@vitest/browser@3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))(vitest@3.2.4)':
     dependencies:
       '@testing-library/dom': 10.4.1
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
-      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@vitest/utils': 3.2.4
       magic-string: 0.30.19
       sirv: 3.0.2
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)
+      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
       ws: 8.18.3
     optionalDependencies:
       playwright: 1.55.0
@@ -4068,9 +4298,9 @@ snapshots:
       std-env: 3.9.0
       test-exclude: 7.0.1
       tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)
+      vitest: 3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     optionalDependencies:
-      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -4082,13 +4312,13 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))':
+  '@vitest/mocker@3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.19
     optionalDependencies:
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -4258,6 +4488,23 @@ snapshots:
       node-releases: 2.0.21
       update-browserslist-db: 1.1.3(browserslist@4.26.0)
 
+  c12@3.3.0(magicast@0.3.5):
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.2
+      defu: 6.1.4
+      dotenv: 17.2.2
+      exsolve: 1.0.7
+      giget: 2.0.0
+      jiti: 2.5.1
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 2.0.0
+      pkg-types: 2.3.0
+      rc9: 2.1.2
+    optionalDependencies:
+      magicast: 0.3.5
+
   cac@6.7.14: {}
 
   call-bind-apply-helpers@1.0.2:
@@ -4276,6 +4523,8 @@ snapshots:
     dependencies:
       call-bind-apply-helpers: 1.0.2
       get-intrinsic: 1.3.0
+
+  call-me-maybe@1.0.2: {}
 
   callsites@3.1.0: {}
 
@@ -4298,15 +4547,29 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chownr@3.0.0: {}
 
   chromatic@12.2.0: {}
 
   chromatic@13.1.4: {}
 
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  cliui@8.0.1:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
 
   clsx@2.1.1: {}
 
@@ -4317,6 +4580,10 @@ snapshots:
   color-name@1.1.4: {}
 
   concat-map@0.0.1: {}
+
+  confbox@0.2.2: {}
+
+  consola@3.4.2: {}
 
   convert-source-map@2.0.0: {}
 
@@ -4385,7 +4652,11 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  defu@6.1.4: {}
+
   dequal@2.0.3: {}
+
+  destr@2.0.5: {}
 
   detect-libc@2.0.4: {}
 
@@ -4405,6 +4676,8 @@ snapshots:
     dependencies:
       no-case: 3.0.4
       tslib: 2.8.1
+
+  dotenv@17.2.2: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -4514,6 +4787,8 @@ snapshots:
       is-callable: 1.2.7
       is-date-object: 1.1.0
       is-symbol: 1.1.1
+
+  es6-promise@3.3.1: {}
 
   esbuild-register@3.6.0(esbuild@0.25.9):
     dependencies:
@@ -4637,11 +4912,11 @@ snapshots:
     dependencies:
       eslint: 9.35.0(jiti@2.5.1)
 
-  eslint-plugin-storybook@9.1.3(eslint@9.35.0(jiti@2.5.1))(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)))(typescript@5.8.3):
+  eslint-plugin-storybook@9.1.3(eslint@9.35.0(jiti@2.5.1))(storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)))(typescript@5.8.3):
     dependencies:
       '@typescript-eslint/utils': 8.43.0(eslint@9.35.0(jiti@2.5.1))(typescript@5.8.3)
       eslint: 9.35.0(jiti@2.5.1)
-      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      storybook: 9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4723,7 +4998,11 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eta@2.2.0: {}
+
   expect-type@1.2.2: {}
+
+  exsolve@1.0.7: {}
 
   fast-deep-equal@3.1.3: {}
 
@@ -4738,6 +5017,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-safe-stringify@2.1.1: {}
 
   fastq@1.19.1:
     dependencies:
@@ -4807,6 +5088,8 @@ snapshots:
 
   gensync@1.0.0-beta.2: {}
 
+  get-caller-file@2.0.5: {}
+
   get-intrinsic@1.3.0:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -4834,6 +5117,15 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.4
+      node-fetch-native: 1.6.7
+      nypm: 0.6.2
+      pathe: 2.0.3
 
   glob-parent@5.1.2:
     dependencies:
@@ -4892,6 +5184,8 @@ snapshots:
       function-bind: 1.1.2
 
   html-escaper@2.0.2: {}
+
+  http2-client@1.3.5: {}
 
   ignore@5.3.2: {}
 
@@ -5229,6 +5523,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  nanoid@5.1.5: {}
+
   napi-postinstall@0.3.3: {}
 
   natural-compare@1.4.0: {}
@@ -5238,9 +5534,62 @@ snapshots:
       lower-case: 2.0.2
       tslib: 2.8.1
 
+  node-fetch-h2@2.3.0:
+    dependencies:
+      http2-client: 1.3.5
+
+  node-fetch-native@1.6.7: {}
+
+  node-fetch@2.7.0:
+    dependencies:
+      whatwg-url: 5.0.0
+
+  node-readfiles@0.2.0:
+    dependencies:
+      es6-promise: 3.3.1
+
   node-releases@2.0.21: {}
 
   normalize-range@0.1.2: {}
+
+  nypm@0.6.2:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      pathe: 2.0.3
+      pkg-types: 2.3.0
+      tinyexec: 1.0.1
+
+  oas-kit-common@1.0.8:
+    dependencies:
+      fast-safe-stringify: 2.1.1
+
+  oas-linter@3.2.2:
+    dependencies:
+      '@exodus/schemasafe': 1.3.0
+      should: 13.2.3
+      yaml: 1.10.2
+
+  oas-resolver@2.5.6:
+    dependencies:
+      node-fetch-h2: 2.3.0
+      oas-kit-common: 1.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+
+  oas-schema-walker@1.1.5: {}
+
+  oas-validator@5.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      oas-kit-common: 1.0.8
+      oas-linter: 3.2.2
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      reftools: 1.1.9
+      should: 13.2.3
+      yaml: 1.10.2
 
   object-inspect@1.13.4: {}
 
@@ -5274,6 +5623,8 @@ snapshots:
       call-bound: 1.0.4
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
+
+  ohash@2.0.11: {}
 
   open@8.4.2:
     dependencies:
@@ -5344,11 +5695,19 @@ snapshots:
 
   pathval@2.0.1: {}
 
+  perfect-debounce@2.0.0: {}
+
   picocolors@1.1.1: {}
 
   picomatch@2.3.1: {}
 
   picomatch@4.0.3: {}
+
+  pkg-types@2.3.0:
+    dependencies:
+      confbox: 0.2.2
+      exsolve: 1.0.7
+      pathe: 2.0.3
 
   playwright-core@1.55.0: {}
 
@@ -5390,6 +5749,11 @@ snapshots:
   punycode@2.3.1: {}
 
   queue-microtask@1.2.3: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.4
+      destr: 2.0.5
 
   react-docgen-typescript@2.4.0(typescript@5.8.3):
     dependencies:
@@ -5445,6 +5809,8 @@ snapshots:
 
   react@19.1.1: {}
 
+  readdirp@4.1.2: {}
+
   recast@0.23.11:
     dependencies:
       ast-types: 0.16.1
@@ -5469,6 +5835,8 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  reftools@1.1.9: {}
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.8
@@ -5477,6 +5845,8 @@ snapshots:
       get-proto: 1.0.1
       gopd: 1.2.0
       set-function-name: 2.0.2
+
+  require-directory@2.1.1: {}
 
   resolve-from@4.0.0: {}
 
@@ -5576,6 +5946,32 @@ snapshots:
 
   shebang-regex@3.0.0: {}
 
+  should-equal@2.0.0:
+    dependencies:
+      should-type: 1.4.0
+
+  should-format@3.0.3:
+    dependencies:
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+
+  should-type-adaptors@1.1.0:
+    dependencies:
+      should-type: 1.4.0
+      should-util: 1.0.1
+
+  should-type@1.4.0: {}
+
+  should-util@1.0.1: {}
+
+  should@13.2.3:
+    dependencies:
+      should-equal: 2.0.0
+      should-format: 3.0.3
+      should-type: 1.4.0
+      should-type-adaptors: 1.1.0
+      should-util: 1.0.1
+
   side-channel-list@1.0.0:
     dependencies:
       es-errors: 1.3.0
@@ -5636,13 +6032,13 @@ snapshots:
       es-errors: 1.3.0
       internal-slot: 1.1.0
 
-  storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)):
+  storybook@9.1.3(@testing-library/dom@10.4.1)(prettier@3.6.2)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.8.0
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.1)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.9
@@ -5725,6 +6121,45 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
+  swagger-schema-official@2.0.0-bab6bed: {}
+
+  swagger-typescript-api@13.2.7(magicast@0.3.5):
+    dependencies:
+      '@biomejs/js-api': 1.0.0(@biomejs/wasm-nodejs@2.0.5)
+      '@biomejs/wasm-nodejs': 2.0.5
+      '@types/swagger-schema-official': 2.0.25
+      c12: 3.3.0(magicast@0.3.5)
+      citty: 0.1.6
+      consola: 3.4.2
+      eta: 2.2.0
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      nanoid: 5.1.5
+      swagger-schema-official: 2.0.0-bab6bed
+      swagger2openapi: 7.0.8
+      typescript: 5.8.3
+    transitivePeerDependencies:
+      - '@biomejs/wasm-bundler'
+      - '@biomejs/wasm-web'
+      - encoding
+      - magicast
+
+  swagger2openapi@7.0.8:
+    dependencies:
+      call-me-maybe: 1.0.2
+      node-fetch: 2.7.0
+      node-fetch-h2: 2.3.0
+      node-readfiles: 0.2.0
+      oas-kit-common: 1.0.8
+      oas-resolver: 2.5.6
+      oas-schema-walker: 1.1.5
+      oas-validator: 5.0.8
+      reftools: 1.1.9
+      yaml: 1.10.2
+      yargs: 17.7.2
+    transitivePeerDependencies:
+      - encoding
+
   tailwind-merge@3.3.1: {}
 
   tailwindcss@4.1.13: {}
@@ -5752,6 +6187,8 @@ snapshots:
 
   tinyexec@0.3.2: {}
 
+  tinyexec@1.0.1: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5768,6 +6205,8 @@ snapshots:
       is-number: 7.0.0
 
   totalist@3.0.1: {}
+
+  tr46@0.0.3: {}
 
   ts-api-utils@2.1.0(typescript@5.8.3):
     dependencies:
@@ -5896,13 +6335,13 @@ snapshots:
     dependencies:
       punycode: 2.3.1
 
-  vite-node@3.2.4(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1):
+  vite-node@3.2.4(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:
       cac: 6.7.14
       debug: 4.4.3
       es-module-lexer: 1.7.0
       pathe: 2.0.3
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -5917,29 +6356,29 @@ snapshots:
       - tsx
       - yaml
 
-  vite-plugin-svgr@4.5.0(rollup@4.50.1)(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)):
+  vite-plugin-svgr@4.5.0(rollup@4.50.1)(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)):
     dependencies:
       '@rollup/pluginutils': 5.3.0(rollup@4.50.1)
       '@svgr/core': 8.1.0(typescript@5.8.3)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.8.3))
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.8.3)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)):
     dependencies:
       debug: 4.4.3
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.8.3)
     optionalDependencies:
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1):
+  vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -5952,12 +6391,13 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.30.1
+      yaml: 2.8.1
 
-  vitest@3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1):
+  vitest@3.2.4(@types/node@24.3.3)(@vitest/browser@3.2.4)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1):
     dependencies:
       '@types/chai': 5.2.2
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))
+      '@vitest/mocker': 3.2.4(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4
@@ -5975,12 +6415,12 @@ snapshots:
       tinyglobby: 0.2.15
       tinypool: 1.1.1
       tinyrainbow: 2.0.0
-      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
-      vite-node: 3.2.4(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)
+      vite: 7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
+      vite-node: 3.2.4(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 24.3.3
-      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1))(vitest@3.2.4)
+      '@vitest/browser': 3.2.4(playwright@1.55.0)(vite@7.1.5(@types/node@24.3.3)(jiti@2.5.1)(lightningcss@1.30.1)(yaml@2.8.1))(vitest@3.2.4)
     transitivePeerDependencies:
       - jiti
       - less
@@ -5995,7 +6435,14 @@ snapshots:
       - tsx
       - yaml
 
+  webidl-conversions@3.0.1: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-url@5.0.0:
+    dependencies:
+      tr46: 0.0.3
+      webidl-conversions: 3.0.1
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -6063,9 +6510,28 @@ snapshots:
 
   ws@8.18.3: {}
 
+  y18n@5.0.8: {}
+
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yaml@1.10.2: {}
+
+  yaml@2.8.1:
+    optional: true
+
+  yargs-parser@21.1.1: {}
+
+  yargs@17.7.2:
+    dependencies:
+      cliui: 8.0.1
+      escalade: 3.2.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 21.1.1
 
   yocto-queue@0.1.0: {}
 

--- a/src/pages/filter/Filter.tsx
+++ b/src/pages/filter/Filter.tsx
@@ -19,7 +19,6 @@ import {
   SERVING_SIZE,
 } from '@pages/filter/constant/filter-option-constants';
 import Button from '@shared/components/button/Button';
-import Overlay from '@shared/components/overlay/Overlay';
 
 interface FilterState {
   eventType: string | null;
@@ -188,34 +187,26 @@ export default function Filter() {
         />
       </div>
 
-      <Overlay
+      <BottomSheet
         isOpen={isBottomSheetOpen}
-        position='bottom'
-        handleClose={handleCloseCalendar}
-      >
-        <BottomSheet
-          isOpen={isBottomSheetOpen}
-          handleCloseBottomSheet={handleCloseCalendar}
-          sheetContent={
-            currentDateIndex !== null ? (
-              <Calendar
-                selectedDate={
-                  filters.date?.[currentDateIndex] ?? {
-                    startDate: null,
-                    endDate: null,
-                  }
+        handleCloseBottomSheet={handleCloseCalendar}
+        sheetContent={
+          currentDateIndex !== null ? (
+            <Calendar
+              selectedDate={
+                filters.date?.[currentDateIndex] ?? {
+                  startDate: null,
+                  endDate: null,
                 }
-                handleApplyDate={date =>
-                  handleApplyDate(date, currentDateIndex)
-                }
-                handleCloseBottomSheet={handleCloseCalendar}
-                isOpen={isBottomSheetOpen}
-              />
-            ) : null
-          }
-          sheetHeight={490}
-        />
-      </Overlay>
+              }
+              handleApplyDate={date => handleApplyDate(date, currentDateIndex)}
+              handleCloseBottomSheet={handleCloseCalendar}
+              isOpen={isBottomSheetOpen}
+            />
+          ) : null
+        }
+        sheetHeight={490}
+      />
 
       <div
         className={cn(

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -61,25 +61,18 @@ const Home = () => {
       </Overlay>
 
       {/* BottomSheet */}
-      <Overlay
+
+      <BottomSheet
         isOpen={isBottomSheetOpen}
-        position='bottom'
-        handleClose={handleCloseBottomSheet}
-      >
-        <BottomSheet
-          isOpen={isBottomSheetOpen}
-          handleCloseBottomSheet={handleCloseBottomSheet}
-          sheetContent={
-            <div>
-              <h3 className='mb-[2rem] text-[1.8rem] font-bold'>
-                바텀시트 내용
-              </h3>
-              <p className='mb-[2rem]'>이것은 바텀시트의 내용입니다.</p>
-            </div>
-          }
-          sheetHeight={400}
-        />
-      </Overlay>
+        handleCloseBottomSheet={handleCloseBottomSheet}
+        sheetContent={
+          <div>
+            <h3 className='mb-[2rem] text-[1.8rem] font-bold'>바텀시트 내용</h3>
+            <p className='mb-[2rem]'>이것은 바텀시트의 내용입니다.</p>
+          </div>
+        }
+        sheetHeight={400}
+      />
 
       {/* Search Bar */}
       <section>

--- a/src/shared/components/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/components/bottom-sheet/BottomSheet.tsx
@@ -1,5 +1,6 @@
 import React, { useRef } from 'react';
 
+import Overlay from '@components/overlay/Overlay';
 import useBottomSheetDrag from '@shared/hooks/use-bottom-sheet-drag';
 import { cn } from '@shared/utils/cn';
 
@@ -24,17 +25,23 @@ export default function BottomSheet({
     sheetHeight,
   });
   return (
-    <div
-      ref={sheetRef}
-      className={cn(
-        'fixed bottom-[0rem] left-1/2 flex w-full max-w-[60rem] -translate-x-1/2 flex-col justify-center rounded-t-[3.2rem] bg-white px-[3.2rem]',
-        'transition-transform duration-300 ease-in-out',
-        isOpen ? 'translate-y-0' : 'translate-y-full'
-      )}
-      onClick={e => e.stopPropagation()}
+    <Overlay
+      isOpen={isOpen}
+      position='bottom'
+      handleClose={handleCloseBottomSheet}
     >
-      <div className='bg-grayscale-300 mx-auto my-[1rem] h-[0.35rem] w-[4.1rem] rounded-[10rem]' />
-      <div className='mb-[3.4rem] mt-[2.8rem]'>{sheetContent}</div>
-    </div>
+      <div
+        ref={sheetRef}
+        className={cn(
+          'fixed bottom-[0rem] left-1/2 flex w-full max-w-[60rem] -translate-x-1/2 flex-col justify-center rounded-t-[3.2rem] bg-white px-[3.2rem]',
+          'transition-transform duration-300 ease-in-out',
+          isOpen ? 'translate-y-0' : 'translate-y-full'
+        )}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className='mx-auto my-[1rem] h-[0.35rem] w-[4.1rem] rounded-[10rem] bg-grayscale-300' />
+        <div className='mb-[3.4rem] mt-[2.8rem]'>{sheetContent}</div>
+      </div>
+    </Overlay>
   );
 }


### PR DESCRIPTION
## 📌 Related Issues

<!--관련 이슈 언급 -->

- close #76

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

http://52.79.221.101:8000/swagger-ui/index.html
배포된 swagger에서 응답/ 요청 타입을 자동으로 만들어주는 swagger ts api 세팅 했습니다.

## ⭐ PR Point (To Reviewer)

`pnpm swagger-typescript-api`
를 입력하면 자동으로 ./apis 폴더가 생성됩니다.
주의할 부분은 swagger에서 그대로 가져오는 것이기에 프론트 딴에서 수정하면 안됩니다. (수정해도 어차피 반영안됨)

또한, 찬영님이 말씀해주신 lint error의 원인은 버전 문제입니다.
`  "swagger-typescript-api": "13.2.7",`

위 버전으로 설치해주세요~

## 📷 Screenshot


<img width="241" height="338" alt="스크린샷 2025-09-20 오전 9 51 14" src="https://github.com/user-attachments/assets/288b10a9-78d6-4950-8032-4a3af62ef8cf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 리팩터
  - 홈·필터 페이지의 바텀시트 사용 방식을 통일하고 오버레이 처리로 일관된 열림/닫힘 동작을 제공했습니다.
  - 캘린더(날짜 선택) 표시 흐름을 단순화해 안정성과 사용성을 개선했습니다.
- 잡무(Chores)
  - 인증, 사용자 정보, 예약, 지역 조회, 회원/사장님 영역 등 전반을 아우르는 API 클라이언트를 일괄 생성하여 연동 기반을 확충했습니다.
  - 스키마 기반 API 생성 스크립트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->