### PR TITLE
[Feature/#156] ButtonDate 컴포넌트에 닫기 버튼 추가

### DIFF
--- a/src/pages/filter/Filter.tsx
+++ b/src/pages/filter/Filter.tsx
@@ -37,6 +37,7 @@ export default function Filter() {
     handleOpenCalendar,
     handleCloseCalendar,
     handleApplyFilter,
+    handleDeleteSchedule,
   } = useFilterLogic();
 
   const CATEGORY_WITHOUT_ALL = omit(FOOD_TRUCK_CATEGORIES, 'ALL');
@@ -69,6 +70,7 @@ export default function Filter() {
               startDate={schedule.startDate}
               endDate={schedule.endDate}
               handleOpenCalendar={() => handleOpenCalendar(index)}
+              handleDeleteSchedule={() => handleDeleteSchedule(index)}
             />
           ))}
         </div>

--- a/src/pages/filter/hooks/use-filter-logic.ts
+++ b/src/pages/filter/hooks/use-filter-logic.ts
@@ -16,6 +16,7 @@ import type {
   NeedElectricityValue,
   PaymentMethodValue,
 } from '@shared/types/category-types';
+import { ROUTES } from '@router/constant/routes';
 
 export default function useFilterLogic() {
   const navigate = useNavigate();
@@ -105,7 +106,7 @@ export default function useFilterLogic() {
 
   const handleApplyFilter = () => {
     setGlobalFilters(cleanedLocalFilters);
-    navigate('/reservation');
+    navigate(ROUTES.RESERVATION);
   };
 
   const handleDeleteSchedule = (index: number) => {

--- a/src/pages/filter/hooks/use-filter-logic.ts
+++ b/src/pages/filter/hooks/use-filter-logic.ts
@@ -110,9 +110,7 @@ export default function useFilterLogic() {
 
   const handleDeleteSchedule = (index: number) => {
     setLocalFilters(prev => {
-      const newScheduleArray = [...prev.schedules];
-      newScheduleArray.splice(index, 1);
-
+      const newScheduleArray = prev.schedules.filter((_, i) => i !== index);
       if (newScheduleArray.length === 0) {
         newScheduleArray.push({ startDate: null, endDate: null });
       }

--- a/src/pages/filter/hooks/use-filter-logic.ts
+++ b/src/pages/filter/hooks/use-filter-logic.ts
@@ -38,7 +38,7 @@ export default function useFilterLogic() {
     [localFilters]
   );
 
-  const notFiltered = isEqual(cleanedLocalFilters, initialFilter);
+  const notFiltered = isEqual(cleanedLocalFilters, globalFilters);
 
   const handleGoBack = () => navigate(-1);
 
@@ -74,10 +74,18 @@ export default function useFilterLogic() {
   };
 
   const handleAddSchedule = () => {
-    setLocalFilters(prev => ({
-      ...prev,
-      schedules: [...prev.schedules, { startDate: null, endDate: null }],
-    }));
+    setLocalFilters(prev => {
+      const hasEmptySchedule = prev.schedules.some(
+        s => s.startDate === null && s.endDate === null
+      );
+
+      if (hasEmptySchedule) return prev;
+
+      return {
+        ...prev,
+        schedules: [...prev.schedules, { startDate: null, endDate: null }],
+      };
+    });
   };
 
   const handleResetFilter = () => {
@@ -100,6 +108,19 @@ export default function useFilterLogic() {
     navigate('/reservation');
   };
 
+  const handleDeleteSchedule = (index: number) => {
+    setLocalFilters(prev => {
+      const newScheduleArray = [...prev.schedules];
+      newScheduleArray.splice(index, 1);
+
+      if (newScheduleArray.length === 0) {
+        newScheduleArray.push({ startDate: null, endDate: null });
+      }
+
+      return { ...prev, schedules: newScheduleArray };
+    });
+  };
+
   return {
     localFilters,
     isBottomSheetOpen,
@@ -114,5 +135,6 @@ export default function useFilterLogic() {
     handleOpenCalendar,
     handleCloseCalendar,
     handleApplyFilter,
+    handleDeleteSchedule,
   };
 }

--- a/src/shared/components/button-date/ButtonDate.stories.tsx
+++ b/src/shared/components/button-date/ButtonDate.stories.tsx
@@ -21,6 +21,10 @@ const meta: Meta<typeof ButtonDate> = {
       action: 'open-calendar',
       description: '달력 열기 핸들러(바텀시트/모달 등)',
     },
+    handleDeleteDate: {
+      action: 'delete-date',
+      description: '선택된 날짜 삭제하는 핸들러',
+    },
   },
 };
 

--- a/src/shared/components/button-date/ButtonDate.stories.tsx
+++ b/src/shared/components/button-date/ButtonDate.stories.tsx
@@ -21,7 +21,7 @@ const meta: Meta<typeof ButtonDate> = {
       action: 'open-calendar',
       description: '달력 열기 핸들러(바텀시트/모달 등)',
     },
-    handleDeleteDate: {
+    handleDeleteSchedule: {
       action: 'delete-date',
       description: '선택된 날짜 삭제하는 핸들러',
     },

--- a/src/shared/components/button-date/ButtonDate.tsx
+++ b/src/shared/components/button-date/ButtonDate.tsx
@@ -55,14 +55,17 @@ export default function ButtonDate({
           )}
         </div>
         {startDate && (
-          <Icon
-            name='ic_close'
-            className='text-grayscale-500'
+          <button
+            type='button'
+            aria-label='일정 삭제'
+            className='flex items-center'
             onClick={e => {
               e.stopPropagation();
               handleDeleteSchedule();
             }}
-          />
+          >
+            <Icon name='ic_close' className='text-grayscale-500' />
+          </button>
         )}
       </div>
     </button>

--- a/src/shared/components/button-date/ButtonDate.tsx
+++ b/src/shared/components/button-date/ButtonDate.tsx
@@ -21,6 +21,12 @@ export default function ButtonDate({
   handleDeleteSchedule,
   ...props
 }: ButtonDateProps) {
+  const handleCloseButton = (
+    e: React.MouseEvent<SVGSVGElement, MouseEvent>
+  ) => {
+    e.stopPropagation();
+    handleDeleteSchedule();
+  };
   return (
     <button
       type='button'
@@ -58,10 +64,7 @@ export default function ButtonDate({
           <Icon
             name='ic_close'
             className='text-grayscale-500'
-            onClick={e => {
-              e.stopPropagation();
-              handleDeleteSchedule();
-            }}
+            onClick={handleCloseButton}
             role='button'
             aria-label='일정 삭제'
           />

--- a/src/shared/components/button-date/ButtonDate.tsx
+++ b/src/shared/components/button-date/ButtonDate.tsx
@@ -55,17 +55,16 @@ export default function ButtonDate({
           )}
         </div>
         {startDate && (
-          <button
-            type='button'
-            aria-label='일정 삭제'
-            className='flex items-center'
+          <Icon
+            name='ic_close'
+            className='text-grayscale-500'
             onClick={e => {
               e.stopPropagation();
               handleDeleteSchedule();
             }}
-          >
-            <Icon name='ic_close' className='text-grayscale-500' />
-          </button>
+            role='button'
+            aria-label='일정 삭제'
+          />
         )}
       </div>
     </button>

--- a/src/shared/components/button-date/ButtonDate.tsx
+++ b/src/shared/components/button-date/ButtonDate.tsx
@@ -10,6 +10,7 @@ interface ButtonDateProps
   handleOpenCalendar: () => void;
   startDate: Date | null;
   endDate: Date | null;
+  handleDeleteDate: () => void;
 }
 
 export default function ButtonDate({
@@ -17,13 +18,14 @@ export default function ButtonDate({
   className,
   startDate,
   endDate,
+  handleDeleteDate,
   ...props
 }: ButtonDateProps) {
   return (
     <button
       type='button'
       className={cn(
-        'border-grayscale-300 flex h-[5.4rem] w-full flex-row items-center gap-[1.2rem] rounded-[1.6rem] border px-[2rem]',
+        'flex h-[5.4rem] w-full flex-row items-center gap-[1.2rem] rounded-[1.6rem] border border-grayscale-300 px-[2rem]',
         className
       )}
       onClick={handleOpenCalendar}
@@ -33,22 +35,34 @@ export default function ButtonDate({
         name='ic_calendar'
         className={startDate ? 'text-grayscale-700' : 'text-grayscale-300'}
       />
-      <div className='flex flex-row items-center gap-[0.4rem]'>
-        <span
-          className={cn(
-            'text-grayscale-700 body-m-14',
-            !startDate && 'text-grayscale-300'
+      <div className='flex w-full flex-row items-center justify-between gap-[0.4rem]'>
+        <div className='flex items-center'>
+          <span
+            className={cn(
+              'text-grayscale-700 body-m-14',
+              !startDate && 'text-grayscale-300'
+            )}
+          >
+            {startDate ? dateFormatter(startDate) : '일정을 선택해 주세요.'}
+          </span>
+          {startDate && endDate && (
+            <>
+              <Icon name='ic_dash' className='text-grayscale-500' />
+              <span className='text-grayscale-700 body-m-14'>
+                {dateFormatter(endDate)}
+              </span>
+            </>
           )}
-        >
-          {startDate ? dateFormatter(startDate) : '일정을 선택해 주세요.'}
-        </span>
-        {startDate && endDate && (
-          <>
-            <Icon name='ic_dash' className='text-grayscale-500' />
-            <span className='text-grayscale-700 body-m-14'>
-              {dateFormatter(endDate)}
-            </span>
-          </>
+        </div>
+        {startDate && (
+          <Icon
+            name='ic_close'
+            className='text-grayscale-500'
+            onClick={e => {
+              e.stopPropagation();
+              handleDeleteDate();
+            }}
+          />
         )}
       </div>
     </button>

--- a/src/shared/components/button-date/ButtonDate.tsx
+++ b/src/shared/components/button-date/ButtonDate.tsx
@@ -10,7 +10,7 @@ interface ButtonDateProps
   handleOpenCalendar: () => void;
   startDate: Date | null;
   endDate: Date | null;
-  handleDeleteDate: () => void;
+  handleDeleteSchedule: () => void;
 }
 
 export default function ButtonDate({
@@ -18,7 +18,7 @@ export default function ButtonDate({
   className,
   startDate,
   endDate,
-  handleDeleteDate,
+  handleDeleteSchedule,
   ...props
 }: ButtonDateProps) {
   return (
@@ -60,7 +60,7 @@ export default function ButtonDate({
             className='text-grayscale-500'
             onClick={e => {
               e.stopPropagation();
-              handleDeleteDate();
+              handleDeleteSchedule();
             }}
           />
         )}


### PR DESCRIPTION
## 📌 Related Issues

- close #156 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- ButtonDate 컴포넌트에 닫기 버튼 추가. 날짜가 선택되었을 때만 보임
- 기존 Filter 페이지 적용 버튼 활성화 조건 변경 (notFiltered) 
   - initial 상태와 다를 때 활성화 -> 이전 설정과 변경되었을 때 활성화
- handleAddSchedule 일정 추가하기 시 빈 ButtonDate가 이미 있을 때는 추가 안되도록 수정
- handleDeleteSchedule 로직 추가. 만약 모든 일정 삭제 시 빈 ButtonDate 하나는 남아있도록 함


## ⭐ PR Point (To Reviewer)

- handleDeleteSchedule과 handleAddSchedule 함수의 경우 사용하는 페이지에서 정의해야 합니다!
- 이 때 빈 ButtonDate가 있는 경우에 대한 처리도 함께 해주시면 됩니다!

## 📷 Screenshot

<img width="551" height="391" alt="image" src="https://github.com/user-attachments/assets/aa245aa2-0e75-4aa7-9f0a-3fbb82feaf4f" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 예약된 날짜 개별 삭제 기능 추가: 일정 항목 옆의 삭제 버튼으로 특정 일정을 바로 제거할 수 있습니다.

* **개선사항**
  * 버튼 레이아웃 및 날짜 표시 개선: 시작일/종료일이 더 명확히 표시됩니다.
  * 삭제 동작 접근성 개선: 삭제 버튼에 aria-label 및 버튼 역할이 추가되어 보조기기/키보드 사용성이 향상됩니다.
  * 빈 일정 중복 추가 방지 및 삭제 후 빈 일정 자동 보장으로 일정 관리가 더 직관적입니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->