### PR TITLE
[Feature/#174] 약관동의 바텀시트 컴포넌트 구현

### DIFF
--- a/src/assets/svg/ic_sprite.svg
+++ b/src/assets/svg/ic_sprite.svg
@@ -111,4 +111,7 @@
   <symbol id="ic_plus" viewBox="0 0 18 18" fill="none">
     <path d="M8.5 5V8.5M8.5 8.5V12M8.5 8.5L12 8.5M8.5 8.5H5" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
   </symbol>
+  <symbol id="ic_check_agreement" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 26 26" fill="none">
+    <path d="M7 14L12.3333 19L19 9" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+  </symbol>
 </svg>

--- a/src/pages/home/Home.tsx
+++ b/src/pages/home/Home.tsx
@@ -4,10 +4,14 @@ import Overlay from '@layout/overlay/Overlay';
 import Input from '@ui/input/Input';
 import { Icon } from '@icon/Icon';
 import RatingBottomSheet from '@ui/rating-bottom-sheet/RatingBottomSheet';
+import AgreeToTermsBottomSheet from '@shared/components/agree-to-terms/AgreeToTermsBottomSheet';
 
 const Home = () => {
   // BottomSheet states
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+
+  const [isAgreementBottomSheetOpen, setIsAgreementBottomSheetOpen] =
+    useState(true);
 
   // Modal states
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -21,6 +25,10 @@ const Home = () => {
 
   const handleCloseBottomSheet = () => {
     setIsBottomSheetOpen(false);
+  };
+
+  const handleCloseAgreementBottomSheet = () => {
+    setIsAgreementBottomSheetOpen(false);
   };
 
   const handleOpenModal = () => {
@@ -103,6 +111,11 @@ const Home = () => {
         </div>
       </section>
       <Icon name='ic_chat_dot' className='text-primary-500' />
+      <AgreeToTermsBottomSheet
+        isAgreed={!isAgreementBottomSheetOpen}
+        isForOwner={false}
+        handleCloseBottomSheet={handleCloseAgreementBottomSheet}
+      />
     </div>
   );
 };

--- a/src/shared/components/agree-to-terms/AgreeToTermsBottomSheet.tsx
+++ b/src/shared/components/agree-to-terms/AgreeToTermsBottomSheet.tsx
@@ -1,0 +1,107 @@
+import { useState } from 'react';
+
+import BottomSheet from '@components/layout/bottom-sheet/BottomSheet';
+import Button from '@components/ui/button/Button';
+import ButtonCheck from '@components/ui/button-check/ButtonCheck';
+import AgreementItem from '@components/agree-to-terms/AgreementItem';
+import {
+  MEMBER_AGREEMENT_INITIAL_ITEMS,
+  OWNER_AGREEMENT_INITIAL_ITEMS,
+  type AgreementItemType,
+} from '@components/agree-to-terms/constants/agreement';
+
+interface AgreeToTermsBottomSheetProps {
+  isAgreed: boolean;
+  isForOwner?: boolean;
+  handleCloseBottomSheet: () => void;
+}
+
+export default function AgreeToTermsBottomSheet({
+  isAgreed,
+  isForOwner = false,
+  handleCloseBottomSheet,
+}: AgreeToTermsBottomSheetProps) {
+  const initialItems = isForOwner
+    ? OWNER_AGREEMENT_INITIAL_ITEMS
+    : MEMBER_AGREEMENT_INITIAL_ITEMS;
+
+  const [agreementItems, setAgreementItems] =
+    useState<AgreementItemType[]>(initialItems);
+  const [isAgreeToAll, setIsAgreeToAll] = useState(false);
+
+  const isAllRequiredAgreed = agreementItems
+    .filter(item => item.isRequired)
+    .every(item => item.isAgreed);
+
+  const handleToggleAgreeToAll = () => {
+    setIsAgreeToAll(!isAgreeToAll);
+    setAgreementItems(prev =>
+      prev.map(item => ({
+        ...item,
+        isAgreed: !isAgreeToAll,
+      }))
+    );
+  };
+
+  const handleToggleAgree = (id: string) => {
+    setAgreementItems(prev => {
+      const updated = prev.map(item =>
+        item.id === id ? { ...item, isAgreed: !item.isAgreed } : item
+      );
+
+      const allAgreed = updated.every(item => item.isAgreed);
+
+      setIsAgreeToAll(allAgreed);
+
+      return updated;
+    });
+  };
+
+  // TODO : 서버에 동의하기 정보 보내도록 api 연동
+  const handleConfirmAgreement = () => {
+    console.info(agreementItems);
+    handleCloseBottomSheet();
+  };
+
+  return (
+    <BottomSheet isOpen={!isAgreed} sheetHeight={300}>
+      <div className='flex flex-col'>
+        <h2 className='py-[1rem] text-grayscale-900 heading-sb-18'>
+          {isForOwner && <span className='text-primary-700'>사장님 </span>}
+          서비스 이용을 위한 동의가 필요해요.
+        </h2>
+        <div className='flex flex-col gap-[1.4rem] py-[0.6rem]'>
+          <div className='flex flex-row items-center gap-[1rem] px-[0.5rem]'>
+            <ButtonCheck
+              isChecked={isAgreeToAll}
+              handleToggle={handleToggleAgreeToAll}
+            />
+            <span className='py-[0.5rem] text-grayscale-900 body-m-14'>
+              전체동의
+            </span>
+          </div>
+          <div className='h-[0.1rem] w-full bg-grayscale-100' />
+          <div className='flex flex-col gap-[1rem] px-[0.5rem]'>
+            {agreementItems.map(item => (
+              <AgreementItem
+                key={item.id}
+                agreementItem={item}
+                handleToggleAgree={() => handleToggleAgree(item.id)}
+              />
+            ))}
+          </div>
+        </div>
+        <div className='pt-[2rem]'>
+          <Button
+            variant='cta'
+            buttonStyle={isAllRequiredAgreed ? 'active' : 'disabled'}
+            handleClickButton={handleConfirmAgreement}
+            disabled={!isAllRequiredAgreed}
+          >
+            동의하기
+          </Button>
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/shared/components/agree-to-terms/AgreementItem.tsx
+++ b/src/shared/components/agree-to-terms/AgreementItem.tsx
@@ -16,24 +16,32 @@ export default function AgreementItem({
 
   return (
     <div className='flex flex-row items-center gap-[1rem]'>
-      <Icon
-        name='ic_check_agreement'
-        className={
-          agreementItem.isAgreed ? 'text-primary-700' : 'text-grayscale-300'
-        }
+      <button
+        type='button'
+        className='flex cursor-pointer items-center'
         onClick={handleToggleAgree}
-        width={26}
-        height={26}
-      />
+      >
+        <Icon
+          name='ic_check_agreement'
+          className={
+            agreementItem.isAgreed ? 'text-primary-700' : 'text-grayscale-300'
+          }
+          width={26}
+          height={26}
+        />
+      </button>
+
       <div className='flex flex-1 flex-row items-center justify-between py-[0.5rem]'>
         <span className='text-grayscale-900 body-m-14'>
           {agreementItem.label}
         </span>
-        <Icon
-          name='ic_next'
-          className='text-grayscale-500'
+        <button
+          type='button'
+          className='flex cursor-pointer items-center'
           onClick={handleToDetailsPage}
-        />
+        >
+          <Icon name='ic_next' className='text-grayscale-500' />
+        </button>
       </div>
     </div>
   );

--- a/src/shared/components/agree-to-terms/AgreementItem.tsx
+++ b/src/shared/components/agree-to-terms/AgreementItem.tsx
@@ -1,0 +1,40 @@
+import { Icon } from '@components/icon/Icon';
+import type { AgreementItemType } from '@components/agree-to-terms/constants/agreement';
+
+interface AgreementItemProps {
+  agreementItem: AgreementItemType;
+  handleToggleAgree: () => void;
+}
+
+export default function AgreementItem({
+  agreementItem,
+  handleToggleAgree,
+}: AgreementItemProps) {
+  const handleToDetailsPage = () => {
+    window.open(agreementItem.viewDetails, '_blank');
+  };
+
+  return (
+    <div className='flex flex-row items-center gap-[1rem]'>
+      <Icon
+        name='ic_check_agreement'
+        className={
+          agreementItem.isAgreed ? 'text-primary-700' : 'text-grayscale-300'
+        }
+        onClick={handleToggleAgree}
+        width={26}
+        height={26}
+      />
+      <div className='flex flex-1 flex-row items-center justify-between py-[0.5rem]'>
+        <span className='text-grayscale-900 body-m-14'>
+          {agreementItem.label}
+        </span>
+        <Icon
+          name='ic_next'
+          className='text-grayscale-500'
+          onClick={handleToDetailsPage}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/shared/components/agree-to-terms/constants/agreement.ts
+++ b/src/shared/components/agree-to-terms/constants/agreement.ts
@@ -1,0 +1,68 @@
+interface AgreementItemType {
+  id: string;
+  isAgreed: boolean;
+  label: string;
+  viewDetails: string;
+  isRequired: boolean;
+}
+
+// TODO: 추후 링크 연동 (viewDetails)
+const MEMBER_AGREEMENT_INITIAL_ITEMS: AgreementItemType[] = [
+  {
+    id: 'TERMS_MEMBER',
+    isAgreed: false,
+    label: '차콜 회원 약관 및 동의사항',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: true,
+  },
+  {
+    id: 'TERMS_PERSONAL_INFO',
+    isAgreed: false,
+    label: '개인정보 수집 및 이용 동의',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: true,
+  },
+  {
+    id: 'TERMS_LOCATION',
+    isAgreed: false,
+    label: '위치정보 이용약관 (선택)',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: false,
+  },
+  {
+    id: 'TERMS_MARKETING',
+    isAgreed: false,
+    label: '마케팅 수신 동의 (선택)',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: false,
+  },
+];
+const OWNER_AGREEMENT_INITIAL_ITEMS: AgreementItemType[] = [
+  {
+    id: 'TERMS_BIZ_REGISTRATION',
+    isAgreed: false,
+    label: '사업자 등록 및 서류 제출 관련 동의',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: true,
+  },
+  {
+    id: 'TERMS_TRADE_NOTICE',
+    isAgreed: false,
+    label: '거래 관련 고지 및 책임 약관',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: true,
+  },
+  {
+    id: 'TERMS_CONTENT_USAGE',
+    isAgreed: false,
+    label: '콘텐츠 사용 동의 및 푸드트럭 추천 동의(선택)',
+    viewDetails: 'https://www.naver.com/',
+    isRequired: false,
+  },
+];
+
+export {
+  type AgreementItemType,
+  MEMBER_AGREEMENT_INITIAL_ITEMS,
+  OWNER_AGREEMENT_INITIAL_ITEMS,
+};

--- a/src/shared/components/icon/Icon.stories.tsx
+++ b/src/shared/components/icon/Icon.stories.tsx
@@ -33,6 +33,7 @@ const iconIds: IconId[] = [
   'ic_time',
   'ic_phone',
   'ic_dropdown',
+  'ic_check_agreement',
 ];
 
 const meta: Meta<typeof Icon> = {

--- a/src/shared/components/icon/Icon.tsx
+++ b/src/shared/components/icon/Icon.tsx
@@ -7,6 +7,7 @@ export type IconId =
   | 'ic_chat'
   | 'ic_chat_dot'
   | 'ic_check'
+  | 'ic_check_agreement'
   | 'ic_close'
   | 'ic_close_white'
   | 'ic_confirm'

--- a/src/shared/components/layout/bottom-sheet/BottomSheet.tsx
+++ b/src/shared/components/layout/bottom-sheet/BottomSheet.tsx
@@ -6,7 +6,7 @@ import { cn } from '@shared/utils/cn';
 
 interface BottomSheetProps {
   isOpen: boolean;
-  handleCloseBottomSheet: () => void;
+  handleCloseBottomSheet?: () => void;
   children: React.ReactNode;
   sheetHeight: number;
 }
@@ -24,6 +24,7 @@ export default function BottomSheet({
     handleCloseBottomSheet,
     sheetHeight,
   });
+
   return (
     <Overlay
       isOpen={isOpen}
@@ -39,7 +40,7 @@ export default function BottomSheet({
         )}
         onClick={e => e.stopPropagation()}
       >
-        <div className='bg-grayscale-300 mx-auto my-[1rem] h-[0.35rem] w-[4.1rem] rounded-[10rem]' />
+        <div className='mx-auto my-[1rem] h-[0.35rem] w-[4.1rem] rounded-[10rem] bg-grayscale-300' />
         <div className='mb-[3.4rem]'>{children}</div>
       </div>
     </Overlay>

--- a/src/shared/components/layout/overlay/Overlay.tsx
+++ b/src/shared/components/layout/overlay/Overlay.tsx
@@ -4,7 +4,7 @@ import { cn } from '@utils/cn';
 interface OverlayProps {
   isOpen?: boolean;
   position?: 'center' | 'bottom' | 'top' | 'left' | 'right';
-  handleClose: () => void;
+  handleClose?: () => void;
   children?: React.ReactNode;
   className?: string;
 }
@@ -32,7 +32,7 @@ export default function Overlay({
   }, [isOpen]);
 
   const handleOverlayClick = (e: React.MouseEvent<HTMLDivElement>) => {
-    if (e.target === e.currentTarget) {
+    if (e.target === e.currentTarget && handleClose) {
       handleClose();
     }
   };

--- a/src/shared/hooks/use-bottom-sheet-drag.ts
+++ b/src/shared/hooks/use-bottom-sheet-drag.ts
@@ -2,7 +2,7 @@ import React, { useEffect, useRef } from 'react';
 
 interface UseBottomSheetDragProps {
   sheetRef: React.RefObject<HTMLDivElement | null>;
-  handleCloseBottomSheet: () => void;
+  handleCloseBottomSheet?: () => void;
   sheetHeight: number;
 }
 
@@ -57,7 +57,7 @@ export default function useBottomSheetDrag({
       if (!isDragging.current || !canDrag.current) return;
       const diff = currentY.current - startY.current;
 
-      if (diff > 100) {
+      if (diff > 100 && handleCloseBottomSheet) {
         handleCloseBottomSheet();
       }
 


### PR DESCRIPTION
## 📌 Related Issues

- close #174 

## ✅ 체크 리스트

- [x] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [x] 빌드가 성공했나요? (pnpm build)
- [x] 컨벤션을 지켰나요?
- [x] 이슈는 등록했나요?
- [x] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- constants에 관련 타입과 초기값 설정.
- AgreementItem 컴포넌트 구현.
   - 체크 버튼 클릭 시 해당 약관에 체크 표시의 색이 변하도록 함
   - 화살표 클릭 시 새 탭으로 `viewDetails`에 정의된 페이지가 열리도록 함
- AgreementToTermsBottomSheet 구현.
   - isForOwner에 따라 다른 뷰 보이도록 함
   - handleToggleAgreeToAll 호출 시 모든 동의사항 체크되도록 함
   - handleToggleAgree 호출 시 아이템 각각 체크
   - `isRequired`가 `true`인 모든 사항이 체크되었을 때 동의하기 버튼 `active`
 
- 유저가 강제로 바텀시트를 내리는 것을 방지하기 위해 아래 3가지 파일에서 close 관련 함수 prop 선택적 prop으로 변경함
   - BottomSheet, useBottomSheetDrag : handleCloseBottomSheet
   - Overlay : handleClose

## ⭐ PR Point (To Reviewer)

- 약관 동의가 필요하다면 해당 페이지에서 isAgreed와 isForOwner, handleCloseBottomSheet를 prop으로 넘겨주면 됩니다!

## 📷 Screenshot

<img width="771" height="570" alt="image" src="https://github.com/user-attachments/assets/356cac43-0ff4-4160-9103-2aa6b94e8943" />
<img width="738" height="465" alt="image" src="https://github.com/user-attachments/assets/2a70a5d6-671f-41f7-a497-fa590e1cbfdf" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 앱 실행 시 약관 동의 바텀시트가 표시됩니다.
  * 전체 동의 또는 개별 약관 항목을 선택할 수 있습니다.
  * 각 약관 항목의 상세 내용을 새 탭에서 확인할 수 있습니다.
  * 필수 약관 모두 동의 시에만 확인 버튼이 활성화됩니다.
  * 약관 선택을 위한 새로운 체크 아이콘이 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->