### PR TITLE
[Feature/#178] feature chat menu

### DIFF
--- a/apis/FoodTrucks.ts
+++ b/apis/FoodTrucks.ts
@@ -19,6 +19,7 @@ import {
   GetFoodTruckDetailsData,
   GetFoodTruckMenusData,
   GetFoodTrucksData,
+  GetTopRatedFoodTrucksData,
   ImageRequest,
   IsNameDuplicatedData,
   SearchFoodTruckMenusData,
@@ -312,6 +313,28 @@ export class FoodTrucks<
       path: `/food-trucks/${foodTruckId}/menus/search`,
       method: "GET",
       query: query,
+      secure: true,
+      ...params,
+    });
+  /**
+   * @description 평점이 높은 푸드트럭을 조회합니다.
+   *
+   * @tags FoodTruck API
+   * @name GetTopRatedFoodTrucks
+   * @summary [홈화면용] 평점 높은 푸드트럭 조회
+   * @request GET:/food-trucks/top-rated
+   * @secure
+   * @response `200` `GetTopRatedFoodTrucksData` OK
+   * @response `400` `void`
+   * @response `403` `void`
+   * @response `404` `void`
+   * @response `405` `void`
+   * @response `500` `void`
+   */
+  getTopRatedFoodTrucks = (params: RequestParams = {}) =>
+    this.request<GetTopRatedFoodTrucksData, void>({
+      path: `/food-trucks/top-rated`,
+      method: "GET",
       secure: true,
       ...params,
     });

--- a/apis/Owners.ts
+++ b/apis/Owners.ts
@@ -41,8 +41,8 @@ import {
   UpdateMenuRequest,
   UpdateMenuStatusData,
   UpdateMenuStatusRequest,
-} from './data-contracts';
-import { ContentType, HttpClient, RequestParams } from './http-client';
+} from "./data-contracts";
+import { ContentType, HttpClient, RequestParams } from "./http-client";
 
 export class Owners<
   SecurityDataType = unknown,
@@ -66,11 +66,11 @@ export class Owners<
     foodTruckId: number,
     menuId: number,
     data: UpdateMenuRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<UpdateMenuData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/menus/${menuId}`,
-      method: 'PUT',
+      method: "PUT",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -94,11 +94,11 @@ export class Owners<
   deleteMenu = (
     foodTruckId: number,
     menuId: number,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<DeleteMenuData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/menus/${menuId}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -120,11 +120,11 @@ export class Owners<
   updateChatTemplate = (
     chatTemplateId: number,
     data: UpdateChatTemplateRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<UpdateChatTemplateData, void>({
       path: `/owners/me/chat-templates/${chatTemplateId}`,
-      method: 'PUT',
+      method: "PUT",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -148,7 +148,7 @@ export class Owners<
   deleteChatTemplate = (chatTemplateId: number, params: RequestParams = {}) =>
     this.request<DeleteChatTemplateData, void>({
       path: `/owners/me/chat-templates/${chatTemplateId}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -171,11 +171,11 @@ export class Owners<
   updateBankAccount = (
     bankAccountId: number,
     data: UpdateBankAccountRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<UpdateBankAccountData, void>({
       path: `/owners/me/bank-accounts/${bankAccountId}`,
-      method: 'PUT',
+      method: "PUT",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -200,7 +200,7 @@ export class Owners<
   deleteBankAccount = (bankAccountId: number, params: RequestParams = {}) =>
     this.request<DeleteBankAccountData, void>({
       path: `/owners/me/bank-accounts/${bankAccountId}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });
@@ -221,11 +221,11 @@ export class Owners<
    */
   createNewFoodTruck = (
     data: FoodTruckCreateRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<CreateNewFoodTruckData, void>({
       path: `/owners`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -254,26 +254,26 @@ export class Owners<
        * @default "최신순"
        * @example "최신순"
        */
-      sort?: '최신순' | '오래된순';
+      sort?: "최신순" | "오래된순";
       /**
        * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
        * @format int64
        * @example 120
        */
-      'cursorPagingRequest.cursor'?: number;
+      "cursorPagingRequest.cursor"?: number;
       /**
        * 한 페이지에 조회할 개수
        * @format int32
        * @min 1
        * @default 20
        */
-      'cursorPagingRequest.size'?: number;
+      "cursorPagingRequest.size"?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<GetMenusData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/menus`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
       ...params,
@@ -296,38 +296,11 @@ export class Owners<
   registerMenu = (
     foodTruckId: number,
     data: RegisterMenuRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<RegisterMenuData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/menus`,
-      method: 'POST',
-      body: data,
-      secure: true,
-      type: ContentType.Json,
-      ...params,
-    });
-  /**
-   * @description 푸드트럭 관련 서류 업로드를 위한 presigned URL을 발급받습니다.
-   *
-   * @tags Owner API
-   * @name CreateFoodTruckDocumentPresignedUrls
-   * @summary 푸드트럭 관련 서류 업로드를 위한 presigned URL 발급
-   * @request POST:/owners/me/food-truck-documents/images
-   * @secure
-   * @response `200` `CreateFoodTruckDocumentPresignedUrlsData` OK
-   * @response `400` `void`
-   * @response `403` `void`
-   * @response `404` `void`
-   * @response `405` `void`
-   * @response `500` `void`
-   */
-  createFoodTruckDocumentPresignedUrls = (
-    data: ImageRequest,
-    params: RequestParams = {}
-  ) =>
-    this.request<CreateFoodTruckDocumentPresignedUrlsData, void>({
-      path: `/owners/me/food-truck-documents/images`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -378,7 +351,7 @@ export class Owners<
   getChatTemplates = (params: RequestParams = {}) =>
     this.request<GetChatTemplatesData, void>({
       path: `/owners/me/chat-templates`,
-      method: 'GET',
+      method: "GET",
       secure: true,
       ...params,
     });
@@ -399,11 +372,11 @@ export class Owners<
    */
   registerChatTemplate = (
     data: RegisterChatTemplateRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<RegisterChatTemplateData, void>({
       path: `/owners/me/chat-templates`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -427,7 +400,7 @@ export class Owners<
   getBankAccount = (params: RequestParams = {}) =>
     this.request<GetBankAccountData, void>({
       path: `/owners/me/bank-accounts`,
-      method: 'GET',
+      method: "GET",
       secure: true,
       ...params,
     });
@@ -449,11 +422,11 @@ export class Owners<
    */
   registerBankAccount = (
     data: RegisterBankAccountRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<RegisterBankAccountData, void>({
       path: `/owners/me/bank-accounts`,
-      method: 'POST',
+      method: "POST",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -478,11 +451,11 @@ export class Owners<
     foodTruckId: number,
     menuId: number,
     data: UpdateMenuStatusRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<UpdateMenuStatusData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/menus/${menuId}/change-status`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -506,11 +479,11 @@ export class Owners<
   updateFoodTruckViewedStatus = (
     foodTruckId: number,
     data: UpdateFoodTruckViewedStatusRequest,
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<UpdateFoodTruckViewedStatusData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}/change-status`,
-      method: 'PATCH',
+      method: "PATCH",
       body: data,
       secure: true,
       type: ContentType.Json,
@@ -537,26 +510,26 @@ export class Owners<
        * 조회할 예약 내역 타입
        * @example "예약 대기"
        */
-      viewType: '진행 예정' | '확정 신청' | '완료 내역' | '취소 내역';
+      viewType: "진행 예정" | "확정 신청" | "완료 내역" | "취소 내역";
       /**
        * 마지막으로 조회된 데이터의 ID (다음 페이지 요청 시 사용)
        * @format int64
        * @example 120
        */
-      'cursorPagingRequest.cursor'?: number;
+      "cursorPagingRequest.cursor"?: number;
       /**
        * 한 페이지에 조회할 개수
        * @format int32
        * @min 1
        * @default 20
        */
-      'cursorPagingRequest.size'?: number;
+      "cursorPagingRequest.size"?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<GetOwnerReservationsData, void>({
       path: `/owners/me/reservations`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
       ...params,
@@ -579,7 +552,7 @@ export class Owners<
   getReservationDetail = (reservationId: number, params: RequestParams = {}) =>
     this.request<GetReservationDetailData, void>({
       path: `/owners/me/reservations/${reservationId}`,
-      method: 'GET',
+      method: "GET",
       secure: true,
       ...params,
     });
@@ -614,11 +587,11 @@ export class Owners<
        */
       size?: number;
     },
-    params: RequestParams = {}
+    params: RequestParams = {},
   ) =>
     this.request<GetMyFoodTrucksData, void>({
       path: `/owners/me/food-trucks`,
-      method: 'GET',
+      method: "GET",
       query: query,
       secure: true,
       ...params,
@@ -641,7 +614,7 @@ export class Owners<
   deleteFoodTruck = (foodTruckId: number, params: RequestParams = {}) =>
     this.request<DeleteFoodTruckData, void>({
       path: `/owners/me/food-trucks/${foodTruckId}`,
-      method: 'DELETE',
+      method: "DELETE",
       secure: true,
       ...params,
     });

--- a/apis/data-contracts.ts
+++ b/apis/data-contracts.ts
@@ -1538,6 +1538,39 @@ export interface BaseResponseListFoodTruckMenuResponse {
   data?: FoodTruckMenuResponse[];
 }
 
+export interface BaseResponseListFoodTruckTopRateResponse {
+  isSuccess?: boolean;
+  /** @format int32 */
+  code?: number;
+  message?: string;
+  data?: FoodTruckTopRateResponse[];
+}
+
+export interface FoodTruckTopRateResponse {
+  /**
+   * 푸드트럭 식별자
+   * @format int64
+   * @example 1
+   */
+  foodTruckId?: number;
+  /**
+   * 푸드트럭 이름
+   * @example "푸드트럭"
+   */
+  name?: string;
+  /**
+   * 푸드트럭 대표 사진 URL
+   * @example "http://image.png"
+   */
+  photoUrl?: string;
+  /**
+   * 푸드트럭 평균 평점
+   * @format double
+   * @example 4.5
+   */
+  averageRating?: number;
+}
+
 export interface DeleteFoodTruckImagesRequest {
   /**
    * 삭제할 이미지 URL 목록
@@ -1654,6 +1687,9 @@ export type GetFoodTruckMenusData =
   BaseResponseCursorPagingResponseFoodTruckMenuResponse;
 
 export type SearchFoodTruckMenusData = BaseResponseListFoodTruckMenuResponse;
+
+export type GetTopRatedFoodTrucksData =
+  BaseResponseListFoodTruckTopRateResponse;
 
 export type DeleteFoodTruckData = BaseResponseVoid;
 

--- a/src/pages/@owner/account/@modal/(.)select-bank-bottom-sheet/SelectBankBottomSheet.tsx
+++ b/src/pages/@owner/account/@modal/(.)select-bank-bottom-sheet/SelectBankBottomSheet.tsx
@@ -22,15 +22,14 @@ export default function SelectBankBottomSheet({
       sheetHeight={500}
     >
       <div className='flex flex-col'>
-        <p className='heading-sb-18 py-[2rem] text-black'>은행선택</p>
-        <p className='heading-sb-18 py-[2rem] text-black'>은행선택</p>
+        <p className='py-[2rem] text-black heading-sb-18'>은행선택</p>
         <div className='flex w-full flex-col'>
           {Object.values(BANK).map(option => (
             <button
               type='button'
               key={option}
               onClick={() => handleChange(option)}
-              className='text-grayscale-700 body-m-14 flex w-full items-center justify-between py-[1.5rem]'
+              className='flex w-full items-center justify-between py-[1.5rem] text-grayscale-700 body-m-14'
             >
               <p
                 className={cn(

--- a/src/pages/@owner/message-list/components/MessageForm.tsx
+++ b/src/pages/@owner/message-list/components/MessageForm.tsx
@@ -1,6 +1,5 @@
 import { useState, type ChangeEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ROUTES } from '@router/constant/routes';
 import Button from '@ui/button/Button';
 import { Icon } from '@icon/Icon';
 import Navigation from '@layout/navigation/Navigation';
@@ -30,7 +29,7 @@ export default function MessageForm() {
         onSuccess: () => {
           setSubmit(true);
           toast.success('메시지가 성공적으로 저장되었습니다.');
-          navigate(ROUTES.MESSAGE_LIST);
+          navigate(-1);
         },
         onError: () => {
           toast.error('메시지 저장에 실패했습니다.');
@@ -43,7 +42,7 @@ export default function MessageForm() {
     if (!submit && message.trim()) {
       setIsOpen(true);
     } else {
-      navigate(ROUTES.MESSAGE_LIST);
+      navigate(-1);
     }
   };
 
@@ -53,7 +52,7 @@ export default function MessageForm() {
 
   const handleClickConfirm = () => {
     setIsOpen(false);
-    navigate(ROUTES.MESSAGE_LIST);
+    navigate(-1);
   };
 
   const handleCloseModal = () => {
@@ -85,7 +84,7 @@ export default function MessageForm() {
           handleChange={handleChangeMessage}
         />
       </div>
-      <footer className='fixed-center bottom-[0] bg-white px-[2rem] py-[1.7rem]'>
+      <footer className='bottom-[0] bg-white px-[2rem] py-[1.7rem] fixed-center'>
         <Button
           variant='cta'
           buttonStyle={message.length === 0 ? 'disabled' : 'active'}

--- a/src/pages/chat-room/ChatRoom.tsx
+++ b/src/pages/chat-room/ChatRoom.tsx
@@ -1,8 +1,26 @@
 import { Icon } from '@components/icon/Icon';
 import Navigation from '@components/layout/navigation/Navigation';
 import ChatInputArea from '@pages/chat-room/chat-input-area/ChatInputArea';
+import MessageListBottomSheet from '@pages/chat-room/chat-input-area/components/MessageListBottomSheet';
+import { useState } from 'react';
 
 export default function ChatRoom() {
+  const [isMessageListOpen, setIsMessageListOpen] = useState(false);
+  const [selectedQuickMessage, setSelectedQuickMessage] = useState<
+    string | undefined
+  >(undefined);
+
+  const handleSelectQuickMessage = (message?: string) => {
+    setSelectedQuickMessage(message);
+    setIsMessageListOpen(false);
+  };
+  const handleOpenMessageList = () => {
+    setIsMessageListOpen(true);
+  };
+  const handleCloseMessageList = () => {
+    setIsMessageListOpen(false);
+  };
+
   return (
     <>
       <Navigation
@@ -10,9 +28,19 @@ export default function ChatRoom() {
         text='채팅방'
       />
       <div className='flex flex-col gap-[4rem] p-[2rem]'>채팅 목록</div>
-      <footer className='fixed-center bottom-[0] w-full'>
-        <ChatInputArea />
+      <footer className='bottom-[0] w-full fixed-center'>
+        <ChatInputArea
+          selectedQuickMessage={selectedQuickMessage}
+          handleOpenMessageList={handleOpenMessageList}
+        />
       </footer>
+      {isMessageListOpen && (
+        <MessageListBottomSheet
+          isOpen={isMessageListOpen}
+          handleSelectQuickMessage={handleSelectQuickMessage}
+          handleCloseBottomSheet={handleCloseMessageList}
+        />
+      )}
     </>
   );
 }

--- a/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
+++ b/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
@@ -20,7 +20,7 @@ export default function ChatInputArea() {
   }, [isOpenMenu, setIsOpenMenu]);
   useOnClickOutside(chatAreaRef, closeMenu);
 
-  const role = 'provider';
+  const role = ROLE.PROVIDER;
   const menuLayout = role === ROLE.PROVIDER ? 'grid-cols-4' : 'grid-cols-3';
 
   const items = ALL_MENU_ITEMS.filter(item => item.roles.includes(role));

--- a/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
+++ b/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
@@ -24,14 +24,14 @@ export default function ChatInputArea({
   const cameraInputRef = useRef<HTMLInputElement>(null);
   const chatAreaRef = useRef<HTMLDivElement>(null);
 
-  const { disabledStates, handlers, handleGalleryRef, handleCameraRef } =
-    useExtensionMenu(handleOpenMessageList);
-
   const closeMenu = useCallback(() => {
     if (isOpenMenu) {
       setIsOpenMenu(false);
     }
   }, [isOpenMenu, setIsOpenMenu]);
+
+  const { disabledStates, handlers, handleGalleryRef, handleCameraRef } =
+    useExtensionMenu(handleOpenMessageList, closeMenu);
 
   useOnClickOutside(chatAreaRef, closeMenu);
 

--- a/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
+++ b/src/pages/chat-room/chat-input-area/ChatInputArea.tsx
@@ -1,3 +1,5 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+
 import { Icon } from '@components/icon/Icon';
 import { ROLE } from '@constant/role';
 import ChatInputBar from '@pages/chat-room/chat-input-area/components/ChatInputBar';
@@ -6,18 +8,31 @@ import { ALL_MENU_ITEMS } from '@pages/chat-room/chat-input-area/constants/exten
 import { useOnClickOutside } from '@pages/chat-room/chat-input-area/hooks/use-click-outside';
 import { useExtensionMenu } from '@pages/chat-room/chat-input-area/hooks/use-extension-menu';
 import { cn } from '@utils/cn';
-import { useCallback, useRef, useState } from 'react';
 
-export default function ChatInputArea() {
+interface ChatInputAreaProps {
+  selectedQuickMessage?: string;
+  handleOpenMessageList: () => void;
+}
+
+export default function ChatInputArea({
+  selectedQuickMessage,
+  handleOpenMessageList,
+}: ChatInputAreaProps) {
   const [isOpenMenu, setIsOpenMenu] = useState(false);
-  const { disabledStates, handlers } = useExtensionMenu();
 
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const cameraInputRef = useRef<HTMLInputElement>(null);
   const chatAreaRef = useRef<HTMLDivElement>(null);
+
+  const { disabledStates, handlers, handleGalleryRef, handleCameraRef } =
+    useExtensionMenu(handleOpenMessageList);
+
   const closeMenu = useCallback(() => {
     if (isOpenMenu) {
       setIsOpenMenu(false);
     }
   }, [isOpenMenu, setIsOpenMenu]);
+
   useOnClickOutside(chatAreaRef, closeMenu);
 
   const role = ROLE.PROVIDER;
@@ -25,9 +40,44 @@ export default function ChatInputArea() {
 
   const items = ALL_MENU_ITEMS.filter(item => item.roles.includes(role));
 
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    console.info('선택된 파일:', file);
+
+    // TODO: 파일 업로드 로직, 미리보기, 서버 전송 등
+  };
+
+  useEffect(() => {
+    handleGalleryRef(fileInputRef);
+    handleCameraRef(cameraInputRef);
+  }, [handleGalleryRef, handleCameraRef]);
+
   return (
     <div className='w-full' ref={chatAreaRef}>
-      <ChatInputBar isOpenMenu={isOpenMenu} setIsOpenMenu={setIsOpenMenu} />
+      <ChatInputBar
+        selectedQuickMessage={selectedQuickMessage}
+        isOpenMenu={isOpenMenu}
+        setIsOpenMenu={setIsOpenMenu}
+      />
+      {/* 파일 ref */}
+      <input
+        type='file'
+        accept='image/*'
+        ref={fileInputRef}
+        onChange={handleFileSelect}
+        className='hidden'
+      />
+      {/* 카메라 ref */}
+      <input
+        type='file'
+        accept='image/*'
+        capture='environment'
+        ref={cameraInputRef}
+        onChange={handleFileSelect}
+        className='hidden'
+      />
       {isOpenMenu && (
         <div
           className={cn(

--- a/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
+++ b/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
@@ -1,21 +1,33 @@
-import React, { useRef, useState, type FormEvent } from 'react';
+import React, {
+  useEffect,
+  useRef,
+  useState,
+  type ChangeEvent,
+  type FormEvent,
+} from 'react';
 import { cn } from '@utils/cn';
 import { Icon } from '@components/icon/Icon';
 import useAutosizeTextarea from '@pages/chat-room/chat-input-area/hooks/use-autosize-textarea';
 
 interface ChatInputBarProps {
   isOpenMenu: boolean;
+  selectedQuickMessage?: string;
   setIsOpenMenu: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 export default function ChatInputBar({
   isOpenMenu,
+  selectedQuickMessage,
   setIsOpenMenu,
 }: ChatInputBarProps) {
   const [message, setMessage] = useState('');
 
   const textAreaRef = useRef<HTMLTextAreaElement>(null);
   useAutosizeTextarea(textAreaRef.current, message);
+
+  const handleChangeMessage = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setMessage(e.target.value);
+  };
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -32,6 +44,12 @@ export default function ChatInputBar({
     setIsOpenMenu(false);
   };
 
+  useEffect(() => {
+    if (selectedQuickMessage) {
+      setMessage(selectedQuickMessage);
+    }
+  }, [selectedQuickMessage]);
+
   const textAreaBaseClasses =
     'bg-grayscale-100 body-m-14 w-full resize-none overflow-hidden rounded-[2rem] border-none px-[1.8rem] py-[0.8rem]';
   const textAreaInputclasses =
@@ -44,7 +62,7 @@ export default function ChatInputBar({
     >
       <button
         type='button'
-        className='mr-[1.4rem] flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full bg-grayscale-900'
+        className='mr-[1.4rem] flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full bg-grayscale-900 px-[0.6rem] py-[0.5rem]'
         onClick={handleExtensionClick}
       >
         <Icon
@@ -53,15 +71,13 @@ export default function ChatInputBar({
             'text-white transition-transform duration-300 ease-in-out',
             isOpenMenu ? 'rotate-45' : 'rotate-0'
           )}
-          width={11}
-          height={11}
         />
       </button>
       <textarea
         ref={textAreaRef}
         value={message}
         onFocus={handleCloseExtension}
-        onChange={e => setMessage(e.target.value)}
+        onChange={handleChangeMessage}
         placeholder='메세지를 입력하세요.'
         rows={1}
         className={cn(textAreaBaseClasses, textAreaInputclasses)}

--- a/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
+++ b/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
@@ -3,7 +3,7 @@ import React, {
   useRef,
   useState,
   type ChangeEvent,
-  type FormEvent,
+  type KeyboardEvent,
 } from 'react';
 import { cn } from '@utils/cn';
 import { Icon } from '@components/icon/Icon';
@@ -29,12 +29,22 @@ export default function ChatInputBar({
     setMessage(e.target.value);
   };
 
-  const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
-    e.preventDefault();
+  const handleSubmit = () => {
     if (!message.trim()) return;
     setMessage('');
   };
 
+  const handleKeyDownSubmit = (e: KeyboardEvent<HTMLTextAreaElement>) => {
+    if (e.key === 'Enter') {
+      if (e.shiftKey) {
+        return;
+      }
+      e.preventDefault();
+      if (message.trim() !== '') {
+        handleSubmit();
+      }
+    }
+  };
   const handleExtensionClick = () => {
     textAreaRef.current?.blur();
     setIsOpenMenu(prev => !prev);
@@ -78,6 +88,7 @@ export default function ChatInputBar({
         value={message}
         onFocus={handleCloseExtension}
         onChange={handleChangeMessage}
+        onKeyDown={handleKeyDownSubmit}
         placeholder='메세지를 입력하세요.'
         rows={1}
         className={cn(textAreaBaseClasses, textAreaInputclasses)}

--- a/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
+++ b/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
@@ -61,28 +61,31 @@ export default function ChatInputBar({
   }, [selectedQuickMessage]);
 
   const textAreaBaseClasses =
-    'bg-grayscale-100 body-m-14 w-full resize-none overflow-hidden rounded-[2rem] border-none px-[1.8rem] py-[0.8rem]';
+    'bg-grayscale-100 body-m-14 w-full min-h-[4rem] resize-none overflow-hidden rounded-[2rem] border-none px-[1.8rem] py-[0.9rem]';
   const textAreaInputclasses =
     'caret-grayscale-900 placeholder:text-grayscale-500 focus:outline-none max-h-[10rem]';
 
   return (
     <form
       onSubmit={handleSubmit}
-      className='border-t-1 flex w-full items-center border-grayscale-100 bg-white px-[1.1rem] py-[0.8rem]'
+      className='border-t-1 flex w-full items-end border-grayscale-100 bg-white px-[1.1rem] py-[0.8rem]'
     >
-      <button
-        type='button'
-        className='mr-[1.4rem] flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full bg-grayscale-900 px-[0.6rem] py-[0.5rem]'
-        onClick={handleExtensionClick}
-      >
-        <Icon
-          name='ic_plus'
-          className={cn(
-            'text-white transition-transform duration-300 ease-in-out',
-            isOpenMenu ? 'rotate-45' : 'rotate-0'
-          )}
-        />
-      </button>
+      <div className='mr-[0.5rem] p-[0.9rem]'>
+        <button
+          type='button'
+          className='flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full bg-grayscale-900 px-[0.6rem] py-[0.5rem]'
+          onClick={handleExtensionClick}
+        >
+          <Icon
+            name='ic_plus'
+            className={cn(
+              'text-white transition-transform duration-300 ease-in-out',
+              isOpenMenu ? 'rotate-45' : 'rotate-0'
+            )}
+          />
+        </button>
+      </div>
+
       <textarea
         ref={textAreaRef}
         value={message}
@@ -97,7 +100,7 @@ export default function ChatInputBar({
         type='submit'
         disabled={message.trim() === ''}
         className={cn(
-          'flex h-[3.6rem] w-[3.6rem] items-center justify-center p-[0.8rem]',
+          'flex items-center justify-center px-[0.8rem] py-[0.9rem]',
           message.trim() !== '' ? 'text-primary-700' : 'text-grayscale-300'
         )}
       >

--- a/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
+++ b/src/pages/chat-room/chat-input-area/components/ChatInputBar.tsx
@@ -40,19 +40,21 @@ export default function ChatInputBar({
   return (
     <form
       onSubmit={handleSubmit}
-      className='border-t-1 border-grayscale-100 flex w-full items-end bg-white px-[1.1rem] py-[0.8rem]'
+      className='border-t-1 flex w-full items-center border-grayscale-100 bg-white px-[1.1rem] py-[0.8rem]'
     >
       <button
         type='button'
-        className='bg-grayscale-900 mb-[0.7rem] mr-[0.5rem] flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full p-[0.5rem]'
+        className='mr-[1.4rem] flex h-[2.2rem] w-[2.2rem] flex-shrink-0 items-center justify-center rounded-full bg-grayscale-900'
         onClick={handleExtensionClick}
       >
         <Icon
           name='ic_plus'
           className={cn(
-            'h-[2.2rem] w-[2.2rem] text-white transition-transform duration-300 ease-in-out',
+            'text-white transition-transform duration-300 ease-in-out',
             isOpenMenu ? 'rotate-45' : 'rotate-0'
           )}
+          width={11}
+          height={11}
         />
       </button>
       <textarea

--- a/src/pages/chat-room/chat-input-area/components/MessageListBottomSheet.tsx
+++ b/src/pages/chat-room/chat-input-area/components/MessageListBottomSheet.tsx
@@ -38,6 +38,11 @@ export default function MessageListBottomSheet({
             + 추가하기
           </Button>
         </div>
+        {messageList?.data?.length === 0 && (
+          <span className='text-grayscale-500 caption-m-11'>
+            설정된 메시지가 없습니다. 자주 쓰는 문구를 설정해보세요!
+          </span>
+        )}
         <div className='flex max-h-[30rem] flex-col overflow-y-auto'>
           {messageList?.data?.map((message, index) => (
             <button

--- a/src/pages/chat-room/chat-input-area/components/MessageListBottomSheet.tsx
+++ b/src/pages/chat-room/chat-input-area/components/MessageListBottomSheet.tsx
@@ -1,0 +1,61 @@
+import BottomSheet from '@components/layout/bottom-sheet/BottomSheet';
+import Button from '@components/ui/button/Button';
+import { useOwnerChatTemplates } from '@pages/@owner/message-list/hooks/use-owner-message';
+import { ROUTES } from '@router/constant/routes';
+import { useNavigate } from 'react-router-dom';
+
+interface MessageListBottomSheetProps {
+  isOpen: boolean;
+  handleSelectQuickMessage: (_message?: string) => void;
+  handleCloseBottomSheet: () => void;
+}
+
+export default function MessageListBottomSheet({
+  isOpen,
+  handleSelectQuickMessage,
+  handleCloseBottomSheet,
+}: MessageListBottomSheetProps) {
+  const navigate = useNavigate();
+  const { data: messageList } = useOwnerChatTemplates();
+
+  const handleToAddMessageList = () => {
+    navigate(ROUTES.MESSAGE_FORM);
+  };
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      handleCloseBottomSheet={handleCloseBottomSheet}
+      sheetHeight={1000}
+    >
+      <div className='flex flex-col'>
+        <div className='flex flex-row justify-between py-[2rem]'>
+          <h2 className='heading-sb-18'>자주 쓰는 문구</h2>
+          <Button
+            variant='default'
+            buttonStyle='edit'
+            handleClickButton={handleToAddMessageList}
+          >
+            + 추가하기
+          </Button>
+        </div>
+        <div className='flex max-h-[30rem] flex-col overflow-y-auto'>
+          {messageList?.data?.map((message, index) => (
+            <button
+              key={message.chatTemplateId}
+              type='button'
+              className='flex flex-col items-start gap-[0.6rem] py-[1.5rem]'
+              onClick={() => handleSelectQuickMessage(message.content)}
+            >
+              <span className='text-grayscale-700 title-sb-14'>
+                {index + 1}
+              </span>
+              <span className='text-grayscale-700 caption-m-12'>
+                {message.content}
+              </span>
+            </button>
+          ))}
+        </div>
+      </div>
+    </BottomSheet>
+  );
+}

--- a/src/pages/chat-room/chat-input-area/constants/extension-menu-info.ts
+++ b/src/pages/chat-room/chat-input-area/constants/extension-menu-info.ts
@@ -35,26 +35,6 @@ export const ALL_MENU_ITEMS: MenuItemConfig[] = [
     roles: [ROLE.CLIENT, ROLE.PROVIDER],
   },
   {
-    key: 'view_paper',
-    title: '견적서 보기',
-    iconId: 'ic_view_paper',
-    roles: [ROLE.CLIENT, ROLE.PROVIDER],
-  },
-  {
-    key: 'cancel',
-    title: '예약 취소 신청',
-    iconId: 'ic_cancel',
-    roles: [ROLE.CLIENT, ROLE.PROVIDER],
-  },
-  // Client 전용
-  {
-    key: 'download_paper',
-    title: '견적서 다운',
-    iconId: 'ic_download_paper',
-    roles: [ROLE.CLIENT],
-  },
-  // Provider 전용
-  {
     key: 'ment',
     title: '자주쓰는 문구',
     iconId: 'ic_ment',
@@ -77,5 +57,23 @@ export const ALL_MENU_ITEMS: MenuItemConfig[] = [
     title: '견적서 수정',
     iconId: 'ic_edit_paper',
     roles: [ROLE.PROVIDER],
+  },
+  {
+    key: 'view_paper',
+    title: '견적서 보기',
+    iconId: 'ic_view_paper',
+    roles: [ROLE.CLIENT, ROLE.PROVIDER],
+  },
+  {
+    key: 'download_paper',
+    title: '견적서 다운',
+    iconId: 'ic_download_paper',
+    roles: [ROLE.CLIENT],
+  },
+  {
+    key: 'cancel',
+    title: '예약 취소 신청',
+    iconId: 'ic_cancel',
+    roles: [ROLE.CLIENT, ROLE.PROVIDER],
   },
 ];

--- a/src/pages/chat-room/chat-input-area/hooks/use-click-outside.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-click-outside.ts
@@ -7,6 +7,13 @@ export const useOnClickOutside = (
   useEffect(() => {
     const listener = (event: MouseEvent | TouchEvent) => {
       const el = ref.current;
+
+      const target = event.target as HTMLElement;
+
+      if (target.closest('[data-overlay="true"]')) {
+        return;
+      }
+
       if (!el || el.contains(event.target as Node)) {
         return;
       }

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -1,25 +1,40 @@
 import type { MenuKey } from '@pages/chat-room/chat-input-area/constants/extension-menu-info';
+import { useRef, type RefObject } from 'react';
 
-export const useExtensionMenu = () => {
+export const useExtensionMenu = (handleOpenMessageList: () => void) => {
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+  const cameraRef = useRef<HTMLInputElement | null>(null);
+
+  const handleGalleryRef = (ref: RefObject<HTMLInputElement | null>) => {
+    fileInputRef.current = ref.current;
+  };
+
+  const handleCameraRef = (ref: RefObject<HTMLInputElement | null>) => {
+    fileInputRef.current = ref.current;
+  };
+
+  const isMobile = () => {
+    if (typeof navigator === 'undefined') return false;
+
+    return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
+  };
+
   const disabledStates: Record<MenuKey, boolean> = {
-    gallery: false,
-    camera: true,
-    view_paper: false,
-    cancel: false,
-    download_paper: false,
-    ment: false,
-    cash: false,
-    write_paper: false,
-    edit_paper: false,
+    gallery: false, // 항상 active
+    camera: !isMobile(), // 웹 환경에서 disabled
+    ment: false, // 항상 active
+    cash: false, // 계좌 등록 안했을 시 disabled
+    write_paper: false, // 작성한 견적서가 있을 때 disabled
+    edit_paper: false, // 작성한 견적서가 없을 때 disabled
+    view_paper: false, // 작성한 견적서가 없을 때 disabled
+    download_paper: false, // 확정된 예약일 때만 disabled
+    cancel: false, // 확정된 예약일 때만 disabled
   };
 
   const handlers: Record<MenuKey, () => void> = {
-    gallery: () => console.log('앨범 열기'),
-    camera: () => console.log('카메라 실행'),
-    view_paper: () => console.log('견적서 보기'),
-    cancel: () => console.log('예약 취소'),
-    download_paper: () => console.log('견적서 다운로드'),
-    ment: () => console.log('자주쓰는 문구'),
+    gallery: () => fileInputRef.current?.click(),
+    camera: () => cameraRef.current?.click(),
+    ment: () => handleOpenMessageList(),
     cash: () => console.log('계좌번호'),
     write_paper: () => {
       console.log('견적서 작성');
@@ -27,10 +42,15 @@ export const useExtensionMenu = () => {
     edit_paper: () => {
       console.log('견적서 수정');
     },
+    view_paper: () => console.log('견적서 보기'),
+    download_paper: () => console.log('견적서 다운'),
+    cancel: () => console.log('예약 취소'),
   };
 
   return {
     disabledStates,
     handlers,
+    handleGalleryRef,
+    handleCameraRef,
   };
 };

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -25,15 +25,22 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
   };
 
   const disabledStates: Record<MenuKey, boolean> = {
-    gallery: false, // 항상 active
-    camera: !isMobile(), // 웹 환경에서 disabled
-    ment: false, // 항상 active
-    cash: !bankAccount, // 계좌 등록 안했을 시 disabled
-    write_paper: false, // 작성한 견적서가 있을 때 disabled
-    edit_paper: false, // 작성한 견적서가 없을 때 disabled
-    view_paper: false, // 작성한 견적서가 없을 때 disabled
-    download_paper: false, // 작성한 견적서가 없을 때 disabled
-    cancel: false, // 확정된 예약이 없을 때 disabled. 채팅방과 관련된 예약에 대한 예약상태조회 후 확정 상태가 아니라면 disabled
+    gallery: false,
+    // 웹 환경에서 disabled
+    camera: !isMobile(),
+    ment: false,
+    // 계좌 등록 안했을 시 disabled
+    cash: !bankAccount,
+    // 작성한 견적서가 있을 때 disabled
+    write_paper: false,
+    // 작성한 견적서가 없을 때 disabled
+    edit_paper: false,
+    // 작성한 견적서가 없을 때 disabled
+    view_paper: false,
+    // 작성한 견적서가 없을 때 disabled
+    download_paper: false,
+    // 확정된 예약이 없을 때 disabled. 채팅방과 관련된 예약에 대한 예약상태조회 후 확정 상태가 아니라면 disabled
+    cancel: false,
   };
 
   const handlers: Record<MenuKey, () => void> = {

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -3,7 +3,7 @@ import type { MenuKey } from '@pages/chat-room/chat-input-area/constants/extensi
 export const useExtensionMenu = () => {
   const disabledStates: Record<MenuKey, boolean> = {
     gallery: false,
-    camera: false,
+    camera: true,
     view_paper: false,
     cancel: false,
     download_paper: false,

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -19,7 +19,7 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
   };
 
   const handleCameraRef = (ref: RefObject<HTMLInputElement | null>) => {
-    fileInputRef.current = ref.current;
+    cameraRef.current = ref.current;
   };
 
   const isMobile = () => {
@@ -53,7 +53,8 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
     cash: () =>
       navigator.clipboard
         .writeText(`${bankAccount?.bankName}  ${bankAccount?.accountNumber}`)
-        .then(() => toast.success('클립보드에 복사되었습니다.')),
+        .then(() => toast.success('클립보드에 복사되었습니다.'))
+        .catch(() => toast.error('클립보드 복사에 실패했습니다.')),
     write_paper: () => {
       // TODO: 견적서 작성 페이지로
       navigate(ROUTES.MESSAGE_LIST);

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -6,7 +6,10 @@ import useToast from '@hooks/use-toast';
 import { useNavigate } from 'react-router-dom';
 import { ROUTES } from '@router/constant/routes';
 
-export const useExtensionMenu = (handleOpenMessageList: () => void) => {
+export const useExtensionMenu = (
+  handleOpenMessageList: () => void,
+  closeMenu: () => void
+) => {
   const toast = useToast();
   const navigate = useNavigate();
   const { data: bankAccount } = useFetchAccountData();
@@ -54,7 +57,8 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
       navigator.clipboard
         .writeText(`${bankAccount?.bankName}  ${bankAccount?.accountNumber}`)
         .then(() => toast.success('클립보드에 복사되었습니다.'))
-        .catch(() => toast.error('클립보드 복사에 실패했습니다.')),
+        .catch(() => toast.error('클립보드 복사에 실패했습니다.'))
+        .finally(closeMenu),
     write_paper: () => {
       // TODO: 견적서 작성 페이지로
       navigate(ROUTES.MESSAGE_LIST);

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -32,8 +32,8 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
     write_paper: false, // 작성한 견적서가 있을 때 disabled
     edit_paper: false, // 작성한 견적서가 없을 때 disabled
     view_paper: false, // 작성한 견적서가 없을 때 disabled
-    download_paper: false, // 확정된 예약일 때만 disabled
-    cancel: false, // 확정된 예약일 때만 disabled
+    download_paper: false, // 작성한 견적서가 없을 때 disabled
+    cancel: false, // 확정된 예약이 없을 때 disabled. 채팅방과 관련된 예약에 대한 예약상태조회 후 확정 상태가 아니라면 disabled
   };
 
   const handlers: Record<MenuKey, () => void> = {

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -1,7 +1,13 @@
-import type { MenuKey } from '@pages/chat-room/chat-input-area/constants/extension-menu-info';
 import { useRef, type RefObject } from 'react';
 
+import { useFetchAccountData } from '@pages/@owner/account/hooks/use-account-query';
+import type { MenuKey } from '@pages/chat-room/chat-input-area/constants/extension-menu-info';
+import useToast from '@hooks/use-toast';
+
 export const useExtensionMenu = (handleOpenMessageList: () => void) => {
+  const toast = useToast();
+  const { data: bankAccount } = useFetchAccountData();
+
   const fileInputRef = useRef<HTMLInputElement | null>(null);
   const cameraRef = useRef<HTMLInputElement | null>(null);
 
@@ -15,7 +21,6 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
 
   const isMobile = () => {
     if (typeof navigator === 'undefined') return false;
-
     return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
   };
 
@@ -23,7 +28,7 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
     gallery: false, // 항상 active
     camera: !isMobile(), // 웹 환경에서 disabled
     ment: false, // 항상 active
-    cash: false, // 계좌 등록 안했을 시 disabled
+    cash: !bankAccount, // 계좌 등록 안했을 시 disabled
     write_paper: false, // 작성한 견적서가 있을 때 disabled
     edit_paper: false, // 작성한 견적서가 없을 때 disabled
     view_paper: false, // 작성한 견적서가 없을 때 disabled
@@ -35,7 +40,10 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
     gallery: () => fileInputRef.current?.click(),
     camera: () => cameraRef.current?.click(),
     ment: () => handleOpenMessageList(),
-    cash: () => console.log('계좌번호'),
+    cash: () =>
+      navigator.clipboard
+        .writeText(`${bankAccount?.bankName}  ${bankAccount?.accountNumber}`)
+        .then(() => toast.success('클립보드에 복사되었습니다.')),
     write_paper: () => {
       console.log('견적서 작성');
     },

--- a/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
+++ b/src/pages/chat-room/chat-input-area/hooks/use-extension-menu.ts
@@ -3,9 +3,12 @@ import { useRef, type RefObject } from 'react';
 import { useFetchAccountData } from '@pages/@owner/account/hooks/use-account-query';
 import type { MenuKey } from '@pages/chat-room/chat-input-area/constants/extension-menu-info';
 import useToast from '@hooks/use-toast';
+import { useNavigate } from 'react-router-dom';
+import { ROUTES } from '@router/constant/routes';
 
 export const useExtensionMenu = (handleOpenMessageList: () => void) => {
   const toast = useToast();
+  const navigate = useNavigate();
   const { data: bankAccount } = useFetchAccountData();
 
   const fileInputRef = useRef<HTMLInputElement | null>(null);
@@ -52,14 +55,19 @@ export const useExtensionMenu = (handleOpenMessageList: () => void) => {
         .writeText(`${bankAccount?.bankName}  ${bankAccount?.accountNumber}`)
         .then(() => toast.success('클립보드에 복사되었습니다.')),
     write_paper: () => {
-      console.log('견적서 작성');
+      // TODO: 견적서 작성 페이지로
+      navigate(ROUTES.MESSAGE_LIST);
     },
     edit_paper: () => {
-      console.log('견적서 수정');
+      // TODO: 견적서 수정 페이지로
+      navigate(ROUTES.MESSAGE_LIST);
     },
-    view_paper: () => console.log('견적서 보기'),
-    download_paper: () => console.log('견적서 다운'),
-    cancel: () => console.log('예약 취소'),
+    // TODO : 견적서 pdf 띄우도록
+    view_paper: () => alert('견적서 보기'),
+    // TODO : 견적서 pdf 다운로드 되도록
+    download_paper: () => alert('견적서 다운'),
+    // TODO : 예약 취소 신청 로직
+    cancel: () => alert('예약 취소'),
   };
 
   return {

--- a/src/shared/components/layout/overlay/Overlay.tsx
+++ b/src/shared/components/layout/overlay/Overlay.tsx
@@ -54,12 +54,15 @@ export default function Overlay({
 
   return (
     <div
+      data-overlay='true'
       onClick={handleOverlayClick}
       className={cn(
         'fixed left-1/2 top-[0] z-50 flex h-dvh w-full max-w-[60rem] -translate-x-1/2 bg-black/50',
         getPositionClasses(),
         'transition-opacity duration-300 ease-in-out',
-        isOpen ? 'opacity-100' : 'pointer-events-none opacity-0',
+        isOpen
+          ? 'pointer-events-auto opacity-100'
+          : 'pointer-events-none opacity-0',
         className
       )}
       {...props}


### PR DESCRIPTION
## 📌 Related Issues

- close #178 

## ✅ 체크 리스트

- [ ] PR 제목의 형식을 잘 작성했나요? e.g. [Feat/#이슈번호] PR 템플릿 작성
- [ ] 빌드가 성공했나요? (pnpm build)
- [ ] 컨벤션을 지켰나요?
- [ ] 이슈는 등록했나요?
- [ ] 리뷰어와 라벨을 지정했나요?

## 📄 Tasks

- 채팅 메뉴 중 갤러리, 카메라, 자주쓰는 문구, 계좌번호 관련 클릭 시 이벤트 구현
  - 앨범 : 클릭 시, 디바이스 기본 파일 선택 열리도록 구현
  - 카메라 : 클릭 시 카메라가 열리도록 구현. 웹 환경에서는 disabled
  - 자주쓰는 문구 : useOwnerChatTemplates 훅 이용하여 바텀시트 구현. 추가하기 누르면 자주쓰는 문구 등록 페이지로 가고 저장 또는 뒤로가기 시 다시 채팅방으로 돌아오도록 navigate 경로 수정.
  - 계좌번호 : useFetchAccountData 훅으로 계좌정보를 가져오고 클릭 시 클립보드에 복사한 후 성공했으면 토스트메시지 띄워주도록 구현. 등록된 계좌가 없다면 disabled

- 자주쓰는 문구 바텀시트
  - 하나도 없을 때, `설정된 메시지가 없습니다. 자주 쓰는 문구를 설정해보세요!` 텍스트로 설명
  - 문구 클릭 시 ChatInputBar에 자동으로 들어가도록 함
  - 해당 바텀시트 내릴 때 채팅 메뉴도 내려가는 것을 막기 위해 Overlay, BottomSheet 등에 대한 동작 수정

TODO
- 앨범, 카메라 관련하여 선택 시 채팅으로 보내도록 로직 추가해야함
- 예약 취소 신청 관련 로직. 서버와 논의 필요
- 견적서 관련 -> 논의필요

## 📷 Screenshot

<img width="613" height="259" alt="image" src="https://github.com/user-attachments/assets/a0dfed78-39f0-4609-8837-e424e26f83b7" />
<img width="770" height="306" alt="image" src="https://github.com/user-attachments/assets/3b104a8e-dc45-4c7b-aeb1-369f726ee35d" />
<img width="733" height="218" alt="image" src="https://github.com/user-attachments/assets/664a9070-11bf-4c2e-847a-b364bd4d7eb8" />
<img width="726" height="305" alt="image" src="https://github.com/user-attachments/assets/8eddfa5d-7dbd-4919-8105-54d013f3729d" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 인기(Top-rated) 푸드트럭 목록 조회 API 및 관련 데이터 형태 추가
  * 채팅에서 저장된 메시지 템플릿을 선택해 빠르게 삽입 가능
  * 채팅 입력에서 카메라·갤러리 파일 입력 지원 및 업로드 준비 기능 추가
  * 메시지 템플릿 관리용 하단 시트(바텀시트) 추가

* **개선사항**
  * 채팅 입력 흐름(엔터 제출 포함) 및 네비게이션·상태 관리 개선
  * 오버레이 클릭 무시 처리로 상호작용 신뢰성 향상

* **스타일**
  * 코드 스타일·문자열 표기 및 UI 클래스 정리.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->